### PR TITLE
Eval release: Code Generation evals (40 evals)

### DIFF
--- a/EVAL_RELEASE_LOG.md
+++ b/EVAL_RELEASE_LOG.md
@@ -2,6 +2,16 @@
 
 ---
 
+## Apr 14, 2026 — Code Generation Batch 2 (40 evals)
+
+**Directory:** `Evals/`
+
+Released 40 new coding capability evals that raise the complexity and broaden place coverage. 4 additional places are added, alongside with "from-scratch" baseplate scenarios that test larger system creation with multiple steps expected.
+
+Together with this release, we removed unfinalized metadata fields (`difficulty`, `tags`, `expected_tool_calls`, `expected_script_instances`, `expected_non_script_instances`) from all evals to avoid confusion as our understanding of eval taxonomy and model capabilities evolves.
+
+---
+
 ## March 3, 2026 — Debug Evals (30 evals)
 
 **Directory:** `DebugEvals/`

--- a/Evals/001_make_cars_faster.lua
+++ b/Evals/001_make_cars_faster.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "racing.rbxl",
-    tool = nil,
-	tags = {"code_runner"},
-	difficulty = "easy",
-	expected_tool_calls = { "execute_luau" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/002_emit_white_smoke.lua
+++ b/Evals/002_emit_white_smoke.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-	tags = {"code_runner"},
-	difficulty = "medium",
-	expected_tool_calls = { "execute_luau" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/003_make_leaves_fall_colored.lua
+++ b/Evals/003_make_leaves_fall_colored.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "village.rbxl",
-    tool = nil,
-	tags = {"code_runner"},
-	difficulty = "medium",
-	expected_tool_calls = { "execute_luau" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/004_reduce_car_friction_enable_sliding.lua
+++ b/Evals/004_reduce_car_friction_enable_sliding.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "racing.rbxl",
-    tool = nil,
-	tags = {"code_runner"},
-	difficulty = "easy",
-	expected_tool_calls = { "execute_luau" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/007_change_logo_cube_green.lua
+++ b/Evals/007_change_logo_cube_green.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "platformer.rbxl",
-    tool = nil,
-	tags = {"code_runner"},
-	difficulty = "medium",
-	expected_tool_calls = { "execute_luau" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/008_spawn_as_r6.lua
+++ b/Evals/008_spawn_as_r6.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-	tags = {"code_runner"},
-	difficulty = "easy",
-	expected_tool_calls = { "execute_luau" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/010_left_shift_sprint_5s.lua
+++ b/Evals/010_left_shift_sprint_5s.lua
@@ -22,14 +22,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-	tags = {"game_iteration"},
-	difficulty = "medium",
-	expected_tool_calls = { "grep_search", "multi_edit" },
-	runConfig = {
-		serverCheck = nil,
-		clientChecks = {},
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/011_change_height_to_1.lua
+++ b/Evals/011_change_height_to_1.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-	tags = {"game_iteration"},
-	difficulty = "medium",
-	expected_tool_calls = { "grep_search", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/012_remove_legs.lua
+++ b/Evals/012_remove_legs.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
 	},
 	-- optional, placefile to load before running setup function
 	place = "baseplate.rbxl",
-	tool = nil,
-	tags = {"game_iteration"},
-	difficulty = "medium",
-	expected_tool_calls = { "grep_search", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/013_inf_cube_fall.lua
+++ b/Evals/013_inf_cube_fall.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-	tags = {"game_iteration"},
-	difficulty = "easy",
-	expected_tool_calls = { "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/017_make_traffic_light.lua
+++ b/Evals/017_make_traffic_light.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "hard",
-	expected_tool_calls = { "execute_luau", "grep_search", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/018_weather_machine.lua
+++ b/Evals/018_weather_machine.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/019_secret_door_puzzle.lua
+++ b/Evals/019_secret_door_puzzle.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/020_gravity_well.lua
+++ b/Evals/020_gravity_well.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/021_gem_orbiting_part.lua
+++ b/Evals/021_gem_orbiting_part.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local SelectionContextJson = "[{\"instanceName\": \"OrbitPart\", \"className\": \"Part\"}]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/022_add_world_time.lua
+++ b/Evals/022_add_world_time.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-	expected_tool_calls = { "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/023_music_playing_part.lua
+++ b/Evals/023_music_playing_part.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/025_chase_and_damage.lua
+++ b/Evals/025_chase_and_damage.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/026_make_traffic_light_v2.lua
+++ b/Evals/026_make_traffic_light_v2.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "surburban.rbxl",
-	tool = nil,
-	tags = {"game_iteration"},
-	difficulty = "medium",
-	expected_tool_calls = { "grep_search", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/026_make_traffic_light_v3.lua
+++ b/Evals/026_make_traffic_light_v3.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "hard",
-	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/027_firstperson_block.lua
+++ b/Evals/027_firstperson_block.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/029_play_idle_animation.lua
+++ b/Evals/029_play_idle_animation.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-	expected_tool_calls = { "multi_edit" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/030_play_idle_animation_v2.lua
+++ b/Evals/030_play_idle_animation_v2.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "platformer.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-	expected_tool_calls = { "grep_search", "multi_edit" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/033_count_coins.lua
+++ b/Evals/033_count_coins.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "platformer.rbxl",
-    tool = nil,
-    tags = {"code_runner"},
-    difficulty = "medium",
-    expected_tool_calls = { "execute_luau" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/035_laser_tag_regenerate_health.lua
+++ b/Evals/035_laser_tag_regenerate_health.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "laser_tag.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-	expected_tool_calls = { "grep_search", "multi_edit" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/038_platformer_coin_multiple_pickup.lua
+++ b/Evals/038_platformer_coin_multiple_pickup.lua
@@ -24,9 +24,6 @@ local eval: BaseEval = {
                 }
             },
     place = "platformer.rbxl",
-    expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-    expected_script_instances = { "game.ReplicatedStorage.CoinController" },
-    expected_non_script_instances = { },
     runConfig = {
         serverCheck = nil,
         clientChecks = {},

--- a/Evals/038_platformer_coin_multiple_pickup.lua
+++ b/Evals/038_platformer_coin_multiple_pickup.lua
@@ -1,0 +1,311 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+if LoadedCode:FindFirstChild("EvalUtils") then
+	local types = require(LoadedCode.EvalUtils.types)
+	local utils_runs = require(LoadedCode.EvalUtils.utils_runs)
+	local utils_he = require(LoadedCode.EvalUtils.utils_he)
+    local lib = require(LoadedCode.EvalUtils.lib)
+else
+	local types = require(game.LoadedCode.types)
+end
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+    scenario_name = "038_platformer_coin_multiple_pickup",
+    prompt = {
+                {
+                    {
+                        role = "user",
+                        content = [[Make it so that the coins can be picked up multiple times.]],
+                        
+                    }
+                }
+            },
+    place = "platformer.rbxl",
+    expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
+    expected_script_instances = { "game.ReplicatedStorage.CoinController" },
+    expected_non_script_instances = { },
+    runConfig = {
+        serverCheck = nil,
+        clientChecks = {},
+    }
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+    local selectionService = game:GetService("Selection")
+    local selectedInstances = {}
+    for _, selection in ipairs(TableSelectionContext) do
+        for _, instance in ipairs(game:GetDescendants()) do
+            if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+                selectedInstances[#selectedInstances + 1] = instance
+                break
+            end
+        end
+    end
+    selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+    local ReplicatedStorage = game:GetService("ReplicatedStorage")
+    local ServerScriptService = game:GetService("ServerScriptService")
+    
+    local coinController = ReplicatedStorage:FindFirstChild("CoinController", true)
+    
+    if coinController and coinController:IsA("ModuleScript") then
+        coinController.Source = [=[
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Workspace = game:GetService("Workspace")
+
+local Gameplay = ReplicatedStorage:WaitForChild("Gameplay")
+local Constants = require(Gameplay.Constants)
+local disconnectAndClear = require(ReplicatedStorage.Utility.disconnectAndClear)
+local playSoundFromSource = require(ReplicatedStorage.Utility.playSoundFromSource)
+local simpleParticleBurst = require(ReplicatedStorage.Utility.simpleParticleBurst)
+
+local player = Players.LocalPlayer
+local visualTemplate = Gameplay.Objects.Coin
+local pickupSoundTemplate = Gameplay.Sounds.PickupCoin
+local pickupParticlesTemplate = Gameplay.Effects.PickupParticles
+local remotes = Gameplay.Remotes
+local pickupCoinRemote = remotes.PickupCoin
+
+local audioEmitterTemplate = script:FindFirstChild("CoinAudioEmitter")
+if not audioEmitterTemplate then
+    audioEmitterTemplate = Instance.new("Sound")
+    audioEmitterTemplate.Name = "CoinAudioEmitter"
+end
+
+local pickupSoundPitch = 1
+local lastPickup = 0
+local pickedUpCoins = {} 
+
+local CoinController = {}
+CoinController.__index = CoinController
+
+function CoinController.new(coin: BasePart)
+	local visual = visualTemplate:Clone()
+	visual:PivotTo(coin.CFrame)
+	visual.Parent = Workspace
+
+	local audioEmitter = audioEmitterTemplate:Clone()
+	audioEmitter.Parent = coin
+
+	local self = {
+		coin = coin,
+		visual = visual,
+		audioEmitter = audioEmitter,
+		connections = {},
+	}
+	setmetatable(self, CoinController)
+
+	self:initialize()
+
+	return self
+end
+
+function CoinController:initialize()
+	table.insert(
+		self.connections,
+		self.coin.Touched:Connect(function(hit: BasePart)
+			if hit.Parent == player.Character then
+				self:tryPickup()
+			end
+		end)
+	)
+	self:updateVisibility()
+end
+
+function CoinController:tryPickup()
+	if pickedUpCoins[self.coin] then
+		return
+	end
+
+	local timeSinceLastPickup = os.clock() - lastPickup
+	lastPickup = os.clock()
+
+	if timeSinceLastPickup > Constants.COIN_PICKUP_SOUND_PITCH_RESET_TIME then
+		pickupSoundPitch = 1
+	else
+		pickupSoundPitch += Constants.COIN_PICKUP_SOUND_PITCH_INCREASE
+	end
+
+	playSoundFromSource(pickupSoundTemplate, self.audioEmitter, pickupSoundPitch)
+	simpleParticleBurst(pickupParticlesTemplate, self.coin.CFrame)
+
+	pickedUpCoins[self.coin] = true
+	self:updateVisibility() 
+
+	local success = pickupCoinRemote:InvokeServer(self.coin)
+    
+    task.delay(3, function()
+        if self.coin and self.coin.Parent then
+            pickedUpCoins[self.coin] = nil
+            self:updateVisibility() 
+        end
+    end)
+end
+
+function CoinController:updateVisibility()
+	local isPickedUp = pickedUpCoins[self.coin]
+
+	for _, descendant in self.visual:GetDescendants() do
+		if descendant:IsA("BasePart") or descendant:IsA("Decal") then
+			descendant.LocalTransparencyModifier = if isPickedUp then Constants.COIN_PICKUP_TRANSPARENCY else 0
+		elseif descendant:IsA("Light") then
+			descendant.Enabled = not isPickedUp
+		end
+	end
+end
+
+function CoinController:destroy()
+	disconnectAndClear(self.connections)
+	self.visual:Destroy()
+	self.audioEmitter:Destroy()
+end
+
+return CoinController
+]=]
+    end
+
+    local overrideScript = Instance.new("Script")
+    overrideScript.Name = "InfiniteCoinPickupOverride"
+    
+    overrideScript.Source = [=[
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local function ensureLeaderstats(player)
+    if not player:FindFirstChild("leaderstats") then
+        local leaderstats = Instance.new("Folder")
+        leaderstats.Name = "leaderstats"
+        leaderstats.Parent = player
+        
+        local coins = Instance.new("IntValue")
+        coins.Name = "Coins"
+        coins.Value = 0
+        coins.Parent = leaderstats
+    end
+end
+
+Players.PlayerAdded:Connect(ensureLeaderstats)
+for _, player in ipairs(Players:GetPlayers()) do
+    ensureLeaderstats(player)
+end
+
+local Gameplay = ReplicatedStorage:WaitForChild("Gameplay")
+local Remotes = Gameplay:WaitForChild("Remotes")
+local PickupCoin = Remotes:WaitForChild("PickupCoin")
+
+local PICKUP_DISTANCE = 50 
+
+local function onPickupCoin(player, coinPart)
+    if not player.Character then return false end
+    if not coinPart then return false end
+    
+    local distance = (player.Character.PrimaryPart.Position - coinPart.Position).Magnitude
+    if distance > PICKUP_DISTANCE then return false end
+
+    local leaderstats = player:FindFirstChild("leaderstats")
+    if leaderstats then
+        local coins = leaderstats:FindFirstChild("Coins")
+        if coins then
+            coins.Value += 1
+            return true
+        end
+    end
+    return false
+end
+
+PickupCoin.OnServerInvoke = onPickupCoin
+]=]
+    
+    overrideScript.Parent = ServerScriptService
+end
+
+eval.check_scene = function()
+    local ReplicatedStorage = game:GetService("ReplicatedStorage")
+    local ServerScriptService = game:GetService("ServerScriptService")
+
+    local coinController = ReplicatedStorage:FindFirstChild("CoinController", true)
+    assert(coinController, "CoinController module not found in ReplicatedStorage")
+    assert(coinController:IsA("ModuleScript"), "CoinController is not a ModuleScript")
+
+    local serverScript = ServerScriptService:FindFirstChild("InfiniteCoinPickupOverride")
+    if not serverScript then
+         warn("InfiniteCoinPickupOverride script not found in ServerScriptService. Reference code execution might have failed or not persisted.")
+    end
+end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+	local Players = game:GetService("Players")
+	local localPlayer = Players.LocalPlayer
+    
+	local character = localPlayer.Character or localPlayer.CharacterAdded:Wait()
+	local rootPart = character:WaitForChild("HumanoidRootPart", 10)
+
+    local Gameplay = workspace:WaitForChild("Gameplay", 10)
+    local CoinPickups = Gameplay and Gameplay:WaitForChild("CoinPickups", 10)
+    local coins = CoinPickups and CoinPickups:GetChildren() or {}
+    assert(#coins > 0, "No coins found in Workspace to test")
+    local targetCoin = coins[1]
+    
+    local leaderstats = localPlayer:WaitForChild("leaderstats", 15)
+    local coinStat = leaderstats and leaderstats:WaitForChild("Coins", 5)
+
+    local function teleportAway()
+        if character and character.PrimaryPart then
+             character:PivotTo(CFrame.new(targetCoin.Position + Vector3.new(30, 10, 0)))
+             character.PrimaryPart.AssemblyLinearVelocity = Vector3.zero
+        end
+    end
+
+    local function teleportToCoin()
+        if character and character.PrimaryPart then
+            character:PivotTo(CFrame.new(targetCoin.Position))
+            character.PrimaryPart.AssemblyLinearVelocity = Vector3.zero
+            task.wait(0.1)
+            character:PivotTo(CFrame.new(targetCoin.Position) * CFrame.new(0.5, 0.5, 0))
+        end
+    end
+
+    local function waitForStat(targetValue, timeout)
+        local start = os.clock()
+        while os.clock() - start < timeout do
+            if coinStat.Value >= targetValue then
+                return true
+            end
+            task.wait(0.1)
+        end
+        return false
+    end
+
+    teleportAway()
+    task.wait(1) 
+
+    local initialValue = coinStat.Value
+
+    teleportToCoin()
+    local successFirst = waitForStat(initialValue + 1, 4)
+    assert(successFirst, "Failed to pickup coin the first time.")
+    local valueAfterFirst = coinStat.Value
+
+    teleportAway()
+    task.wait(4) 
+
+    teleportToCoin()
+    local successSecond = waitForStat(valueAfterFirst + 1, 4)
+    assert(successSecond, "Failed to pickup coin a second time.")
+end)
+
+return eval

--- a/Evals/041_platformer_make_checkpoints.lua
+++ b/Evals/041_platformer_make_checkpoints.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "platformer.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-    expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[{\"instanceName\": \"OneJump\", \"className\": \"Model\"}]"

--- a/Evals/043_platformer_bouncing_jumper.lua
+++ b/Evals/043_platformer_bouncing_jumper.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "platformer.rbxl",
-	tool = nil,
-	tags = {"game_iteration"},
-	difficulty = "medium",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-	runConfig = {
-		serverCheck = nil,
-		clientChecks = {},
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/048_surburban_fountain_insert.lua
+++ b/Evals/048_surburban_fountain_insert.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"code_runner"},
-    difficulty = "medium",
-    expected_tool_calls = { "execute_luau" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/049_surburban_fridge_door_open.lua
+++ b/Evals/049_surburban_fridge_door_open.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "hard",
-	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/050_surburban_gaspump_explode.lua
+++ b/Evals/050_surburban_gaspump_explode.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-	expected_tool_calls = { "execute_luau", "grep_search", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/052_surburban_trampoline_bounce.lua
+++ b/Evals/052_surburban_trampoline_bounce.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/053_surburban_billboard_change_decal.lua
+++ b/Evals/053_surburban_billboard_change_decal.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-    difficulty = "medium",
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/054_surburban_equip_flashlight.lua
+++ b/Evals/054_surburban_equip_flashlight.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-    expected_tool_calls = { "execute_luau" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/055_surburban_tree_fallcolor_approach.lua
+++ b/Evals/055_surburban_tree_fallcolor_approach.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-    expected_tool_calls = { "grep_search", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/057_surburban_no_trespassing.lua
+++ b/Evals/057_surburban_no_trespassing.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "surburban.rbxl",
-	tool = nil,
-	tags = {"game_iteration"},
-	difficulty = "medium",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-	runConfig = {
-		serverCheck = nil,
-		clientChecks = {},
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/058_surburban_merrygoround_no_fling.lua
+++ b/Evals/058_surburban_merrygoround_no_fling.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-    expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/059_surburban_merrygoround_max_velocity.lua
+++ b/Evals/059_surburban_merrygoround_max_velocity.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-}
 
 local SelectionContextJson = "[]"
 local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)

--- a/Evals/068_village_collectable_plants.lua
+++ b/Evals/068_village_collectable_plants.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "village.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-    expected_tool_calls = { "execute_luau", "multi_edit" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"
@@ -74,10 +66,3 @@ eval.check_game = function()
 		if tool then break end
 		local r = (math.random(-1000, 1000)/3000) + 1
 		humanoid:MoveTo(target.Position+Vector3.new(r,0,r))
-		tool = character:FindFirstChildOfClass("Tool")
-		task.wait(0.25)
-	end
-	assert(tool, "Player did not pick up the plant")
-end
-
-return eval

--- a/Evals/070_village_make_npc_walk.lua
+++ b/Evals/070_village_make_npc_walk.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "village.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "medium",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/071_rainbow_hexagon.lua
+++ b/Evals/071_rainbow_hexagon.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "platformer.rbxl",
-	tool = nil,
-	tags = {"game_iteration"},
-	difficulty = "easy",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local selection_context_json = "[]"
 local table_selection_context = HttpService:JSONDecode(selection_context_json)

--- a/Evals/071_surburban_teleport_sandbox.lua
+++ b/Evals/071_surburban_teleport_sandbox.lua
@@ -20,14 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "surburban.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-    expected_tool_calls = { "execute_luau", "multi_edit" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/073_homestore_dynamic_pricing.lua
+++ b/Evals/073_homestore_dynamic_pricing.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "ugc_homestore.rbxl",
-    tool = nil,
-	tags = {"code_runner"},
-	difficulty = "easy",
-	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-}
 
 local selection_context_json = "[]"
 local table_selection_context = HttpService:JSONDecode(selection_context_json)

--- a/Evals/073_lasertag_crate_drop_disappear.lua
+++ b/Evals/073_lasertag_crate_drop_disappear.lua
@@ -20,14 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "laser_tag.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "hard",
-    expected_tool_calls = { "execute_luau", "grep_search", "read_file", "multi_edit" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/074_red_grass_sway.lua
+++ b/Evals/074_red_grass_sway.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "flat_terrain.rbxl",
-    tool = nil,
-	tags = {"code_runner"},
-	difficulty = "medium",
-	expected_tool_calls = { "execute_luau" },
-}
 
 local selection_context_json = "[]"
 local table_selection_context = HttpService:JSONDecode(selection_context_json)

--- a/Evals/074_village_fire_pit_damage.lua
+++ b/Evals/074_village_fire_pit_damage.lua
@@ -1,0 +1,123 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "074_village_fire_pit_damage",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make all fire pits in the game damage the player when walked over]],
+				request_id = "s20250825_004",
+			},
+		},
+	},
+	place = "village.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree", -- search for fire parts
+		"inspect_instance",
+		"multi_edit",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.Workspace.Structures.House.BuildingFrame.Hearth.FirePart",
+		"game.Workspace.Structures.House.LargeCottage.Hearth.FirePart",
+		"game.Workspace.Structures.Cottage.Hearth.FirePart",
+		"game.Workspace.Structures.Smithy.Bellows.FirePart",
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	for _, obj in workspace:GetDescendants() do
+		if obj.Name == "FirePart" then
+			local FirePart = obj
+			local newScript = Instance.new("Script")
+			-- newScript.RunContext = Enum.RunContext.Client
+			newScript.Source = [[
+			local part = script.Parent
+			part.Touched:Connect(function(part)
+				if part.Parent:FindFirstChild("Humanoid") then
+					local humanoid = part.Parent:FindFirstChild("Humanoid")
+					humanoid.Health -= .1
+				end
+			end)
+			]]
+			newScript.Parent = FirePart
+			newScript.Enabled = false
+			task.wait()
+			newScript.Enabled = true
+		end
+	end
+end
+
+eval.check_scene = function() end
+
+eval.check_game = function()
+	local players = game:GetService("Players")
+	local player = #players:GetPlayers() > 0 and players:GetPlayers()[1] or players.PlayerAdded:Wait()
+	player:LoadCharacter()
+	local character = player.Character or player.CharacterAdded:Wait()
+	local health = character:WaitForChild("Humanoid", math.huge).Health
+	local rootPart = character:WaitForChild("HumanoidRootPart", math.huge)
+	local firePartCount = 0
+
+	for _, object in ipairs(workspace:GetDescendants()) do
+		if object.Name == "FirePart" then
+			local FirePart = object
+			local OriginalSpace = utils_he.getAllReasonableItems()
+			local touchSuccess = false
+			local humanoid = character:WaitForChild("Humanoid", math.huge)
+			local health = humanoid.Health
+			humanoid.Health = 100
+			health = health
+
+			local lostHealth = false
+
+			for i = 1, 8, 1 do
+				lostHealth = false
+				task.wait(0.1)
+				rootPart.CFrame = FirePart.CFrame
+				if
+					character:WaitForChild("Humanoid", math.huge).Health < health
+					and (character.HumanoidRootPart.Position - FirePart.CFrame.p).Magnitude < 1
+				then
+					lostHealth = true
+				end
+				if lostHealth then
+					break
+				end
+				task.wait()
+			end
+
+			assert(lostHealth, "Player did not take any damage.")
+		end
+	end
+end
+
+return eval

--- a/Evals/074_village_fire_pit_damage.lua
+++ b/Evals/074_village_fire_pit_damage.lua
@@ -20,20 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "village.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree", -- search for fire parts
-		"inspect_instance",
-		"multi_edit",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.Workspace.Structures.House.BuildingFrame.Hearth.FirePart",
-		"game.Workspace.Structures.House.LargeCottage.Hearth.FirePart",
-		"game.Workspace.Structures.Cottage.Hearth.FirePart",
-		"game.Workspace.Structures.Smithy.Bellows.FirePart",
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/075_create_npc_enemy.lua
+++ b/Evals/075_create_npc_enemy.lua
@@ -21,11 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "laser_tag.rbxl",
-    tool = nil,
-	tags = {"game_iteration"},
-	difficulty = "easy",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-}
 
 local selection_context_json = "[]"
 local table_selection_context = HttpService:JSONDecode(selection_context_json)

--- a/Evals/075_village_remove_tutorial_assets.lua
+++ b/Evals/075_village_remove_tutorial_assets.lua
@@ -21,14 +21,6 @@ local eval: BaseEval = {
                 }
             },
     place = "village.rbxl",
-    tool = nil,
-    tags = {"code_runner"},
-    difficulty = "easy",
-	expected_tool_calls = { "execute_luau" },
-    runConfig = {
-        serverCheck = nil,
-        clientChecks = {},
-    },
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/076_plane_flyby.lua
+++ b/Evals/076_plane_flyby.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
                 }
             },
     place = "baseplate.rbxl",
-    tool = nil,
-    tags = {"game_iteration"},
-    difficulty = "easy",
-	expected_tool_calls = { "insert_from_marketplace", "grep_search", "read_file", "multi_edit" },
-}
 
 local selection_context_json = "[]"
 local table_selection_context = HttpService:JSONDecode(selection_context_json)

--- a/Evals/079_platformer_roblonk_blue_raise.lua
+++ b/Evals/079_platformer_roblonk_blue_raise.lua
@@ -20,19 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "platformer.rbxl",
-	tool = nil,
-	tags = {},
-	difficulty = "medium",
-	expected_tool_calls = {
-		"game_tree", -- search for roblonk parts
-		"inspect_instance",
-		"execute_luau",
-		"multi_edit",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.Workspace.LevelArt.SkyMeshes.RoBlonk",
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/079_platformer_roblonk_blue_raise.lua
+++ b/Evals/079_platformer_roblonk_blue_raise.lua
@@ -1,0 +1,127 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "079_platformer_roblonk_blue_raise",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make the Roblonk Model blue and raise by 5 studs smoothly when touchiung it, and then back to normal when you stop touching it]],
+				request_id = "s20250825_009",
+			},
+		},
+	},
+	place = "platformer.rbxl",
+	tool = nil,
+	tags = {},
+	difficulty = "medium",
+	expected_tool_calls = {
+		"game_tree", -- search for roblonk parts
+		"inspect_instance",
+		"execute_luau",
+		"multi_edit",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.Workspace.LevelArt.SkyMeshes.RoBlonk",
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local workspace = game:GetService("Workspace")
+	local roblonk = workspace.LevelArt.SkyMeshes.RoBlonk
+	local trigger = Instance.new("Part")
+	trigger.Transparency = 1
+	trigger.CanCollide = false
+	trigger.Size = roblonk.Roblonx.Size + Vector3.new(3, 3, 3)
+	trigger.CFrame = roblonk.Roblonx.CFrame
+	local weld = Instance.new("Weld")
+	weld.Part0 = trigger
+	weld.Part1 = roblonk.Roblonx
+	weld.Parent = trigger
+	local touchScript = Instance.new("Script")
+	touchScript.Source = [[
+local tweenService = game:GetService("TweenService");
+
+local roblonx = script.Parent.Parent.Roblonx;
+local anchor = script.Parent.Parent.Roblonx.anchor;
+
+local touchingPart = nil;
+
+local tweenTouch = tweenService:Create(roblonx, TweenInfo.new(2, Enum.EasingStyle.Linear), {Color = Color3.new(0,0,1)});
+local tweenTouchAnchor = tweenService:Create(anchor, TweenInfo.new(2, Enum.EasingStyle.Linear), {CFrame = anchor.CFrame*CFrame.new(0,5,0)});
+local tweenTouchEnd = tweenService:Create(roblonx, TweenInfo.new(2, Enum.EasingStyle.Linear), {Color = roblonx.Color});
+local tweenTouchAnchorEnd = tweenService:Create(anchor, TweenInfo.new(2, Enum.EasingStyle.Linear), {CFrame = anchor.CFrame});
+
+script.Parent.Touched:Connect(function(part)
+	if (not part:IsDescendantOf(script.Parent.Parent) and not touchingPart) then
+		touchingPart = part;
+		tweenTouch:Play();
+		tweenTouchAnchor:Play();
+	end
+end);
+script.Parent.TouchEnded:Connect(function(part)
+	if (touchingPart == part) then
+		touchingPart = nil;
+		tweenTouchEnd:Play();
+		tweenTouchAnchorEnd:Play();
+	end
+end);
+	]]
+	touchScript.Parent = trigger
+	trigger.Parent = roblonk
+end
+
+eval.check_scene = function() end
+
+eval.check_game = function()
+	local workspace = game:GetService("Workspace")
+	local players = game:GetService("Players")
+	local player = #players:GetPlayers() > 0 and players:GetPlayers()[1] or players.PlayerAdded:Wait()
+	player:LoadCharacter()
+	local roblonk = workspace.LevelArt.SkyMeshes.RoBlonk
+	wait(8) --Stall until the texture fully loads
+	local initialCFrame = roblonk.Roblonx.CFrame
+	local initialColor = roblonk.Roblonx.Color
+	player.Character:PivotTo(roblonk.Roblonx.CFrame * CFrame.new(0, 40, 0))
+	task.wait(4)
+	assert(roblonk.Roblonx.Position.Y >= initialCFrame.Position.Y + 5, "Roblonk did not rise 5 studs")
+	local currentColorH, currentColorS = roblonk.Roblonx.Color:ToHSV()
+	currentColorH *= 360
+	assert(currentColorH <= 245 and currentColorH >= 175 and currentColorS > 0, "Roblonk did not turn blue")
+	task.wait(1)
+	player.Character:MoveTo(workspace.SpawnLocation.Position)
+	task.wait(5)
+	assert(
+		math.abs(roblonk.Roblonx.Position.Y - initialCFrame.Position.Y) <= 0.1,
+		"Roblonk did not go back to its original position"
+	)
+	assert(roblonk.Roblonx.Color == initialColor, "Roblonk did not change back to its normal color")
+end
+
+return eval

--- a/Evals/080_surburban_school_lights_on.lua
+++ b/Evals/080_surburban_school_lights_on.lua
@@ -20,17 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "surburban.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree", -- search for lights
-		"inspect_instance",
-		"execute_luau",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.Workspace.School.Lights",
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/080_surburban_school_lights_on.lua
+++ b/Evals/080_surburban_school_lights_on.lua
@@ -1,0 +1,92 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "080_surburban_school_lights_on",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make every light in the school start in the 'on' state.]],
+				request_id = "s20250825_010",
+			},
+		},
+	},
+	place = "surburban.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree", -- search for lights
+		"inspect_instance",
+		"execute_luau",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.Workspace.School.Lights",
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	for _, lights in game:GetService("Workspace").School.Lights:GetChildren() do
+		if lights:FindFirstChild("LightsOn") then
+			lights["LightsOn"].Value = true
+		end
+		for _, light in lights:GetChildren() do
+			if light:IsA("Model") then
+				if light.Name == "Light" then
+					light.Light.Material = Enum.Material.Neon
+					light.Light.SpotLight.Enabled = true
+				end
+			end
+		end
+	end
+end
+
+eval.check_scene = function()
+	for _, lights in game:GetService("Workspace").School.Lights:GetChildren() do
+		if lights:FindFirstChild("LightsOn") then
+			assert(lights["LightsOn"].Value == true, "LightsOn value not true")
+		end
+		for _, light in lights:GetChildren() do
+			if light:IsA("Model") then
+				if light.Name == "Light" then
+					assert(light.Light.Material == Enum.Material.Neon, "Light material not set to Neon")
+					assert(light.Light.SpotLight.Enabled == true, "Light did not turn on")
+				elseif light.Name == "LightSwitch" then
+					assert(
+						light.Interactive.Orientation.X > 0 or light.Interactive.Orientation.Z > 0,
+						"Light switch is not flipped not turn on"
+					)
+				end
+			end
+		end
+	end
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/081_racing_car_color_change.lua
+++ b/Evals/081_racing_car_color_change.lua
@@ -1,0 +1,294 @@
+--!strict
+
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _,request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName,_ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName,module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "pilot_021",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Please make the cars of this game constantly change colors when they have an occupied driver.]],
+				request_id = "pilot_021"
+			}
+		}
+	},
+	place = "racing.rbxl",
+	expected_tool_calls = { "game_tree", "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		'game.ReplicatedStorage.Car',
+		'game.ReplicatedStorage.Car.Body.Collision.body',
+		'game.ReplicatedStorage.Car.Body.Collision.body["Color"]',
+		'game.ReplicatedStorage.Car.DriverSeat',
+		'game.ReplicatedStorage.Car.DriverSeat["Occupant"]',
+	},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	utils_runs.createPlayerScripts()
+
+end
+
+eval.reference = function()
+	local script = Instance.new("Script")
+	script.Name = "CarColorChanger"
+	script.Source = [[
+        local COLOR_CHANGE_INTERVAL = 0.5
+
+        local function changeCarColor(car)
+            -- Generate a random color
+            local hue = math.random()
+            local sat = math.random() * 0.4 + 0.6
+            local val = math.random() * 0.4 + 0.6
+            local color = Color3.fromHSV(hue, sat, val)
+
+            -- Apply the color to Car.Body.Collision.body, because this is the vehicle's actual outer shell.
+            local bodyPart = car:FindFirstChild("Body")
+            local collision = bodyPart:FindFirstChild("Collision")
+            local body = collision:FindFirstChild("body")
+            body.Color = color
+        end
+
+        local function setupCar(car)
+            -- Prevent double-setup
+            if car:GetAttribute("ColorChangerSetup") then
+                return
+            end
+            car:SetAttribute("ColorChangerSetup", true)
+            
+            -- In case for some reason the car has been discarded or disappeared.
+            if not car or not car:IsDescendantOf(workspace) then
+                return
+            end
+            
+            -- Find the DriverSeat
+            local driverSeat = car:FindFirstChild("DriverSeat", true)
+
+            -- Use polling instead of signal connection to avoid interfering with car's internal systems
+            task.spawn(function()
+                while car and car:IsDescendantOf(workspace) do
+                    if driverSeat.Occupant then
+                        changeCarColor(car)
+                    end
+                    task.wait(COLOR_CHANGE_INTERVAL)
+                end
+            end)
+        end
+
+        -- when the car already exists
+        -- there will be only one car for one player at same time, but if there are multiple players for an online game:
+        for _, obj in workspace:GetDescendants() do
+            if obj:IsA("Model") and obj.Name == "Car" then
+                setupCar(obj)
+            end
+        end
+
+	    -- once the car is added, call the setupCar function
+        workspace.DescendantAdded:Connect(function(obj)
+            if obj:IsA("Model") and obj.Name == "Car" then
+            	-- wait for some possible loading time here
+                task.wait(0.1)
+                setupCar(obj)
+            end
+        end)
+    ]]
+	script.Parent = game:GetService("ServerScriptService")
+end
+
+-- Goal is to ensure that a script exists which has elements any reference
+-- implementation would
+eval.check_scene = function()
+	local ServerScriptService = game:GetService("ServerScriptService")
+
+	local foundColorScript = false
+
+	for _, child in ipairs(ServerScriptService:GetChildren()) do
+		if child:IsA("Script") then
+			local source = child.Source
+			-- I have taken a much better approach here compared to
+			-- previous submissions. Instead of name, now we check for functionalities:
+			-- 1. Color changing (Color, Color3, fromHSV, etc.)
+			-- 2. Driver/Occupant detection (Occupant, DriverSeat, Seat)
+			local hasColorLogic = string.find(source, "Color") ~= nil
+			local hasOccupantLogic = string.find(source, "Occupant") ~= nil or
+				string.find(source, "DriverSeat") ~= nil or
+				string.find(source, "Seat") ~= nil
+
+			if hasColorLogic and hasOccupantLogic then
+				foundColorScript = true
+				break
+			end
+		end
+	end
+
+	assert(foundColorScript, "No script found in ServerScriptService that handles car color changing when driver is present")
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	-- Get the player and character
+	local Players = game:GetService("Players")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+	local player = Players:GetPlayers()[1] or Players.PlayerAdded:Wait()
+	local character = player.Character or player.CharacterAdded:Wait()
+	task.wait(1)
+
+	-- Clone a car from ReplicatedStorage
+	-- at the end our purpose is to get a car and make the player sit in, so there is no need to follow the real game action(use script to make interaction with the component, and let the component generate a car, then make the player to sit in... we directly copy the totally same car from our storage.)
+	local carTemplate = ReplicatedStorage:FindFirstChild("Car")
+	assert(carTemplate, "Car template not found in ReplicatedStorage")
+
+
+	local function spawnCar(location: CFrame, owner: Player?)
+		local carTemplate = ReplicatedStorage:FindFirstChild("Car")
+		local CarConstants = require(carTemplate.Scripts.Constants)
+		local car = carTemplate:Clone()
+		car:PivotTo(location)
+		if owner then
+			car:SetAttribute(CarConstants.CAR_OWNER_ATTRIBUTE, owner.UserId)
+		end
+		car.Parent = workspace
+		return car
+	end
+	-- Use proper spawn instead of direct clone
+	local car = spawnCar(character:GetPivot() * CFrame.new(5, 0, 0), player)
+
+	task.wait(0.5)
+
+	local driverSeat = car:FindFirstChild("DriverSeat", true)
+	assert(driverSeat, "DriverSeat not found in car")
+
+	-- Find the specific body part that changes color: Car.Body.Collision.body
+	local bodyPart = car:FindFirstChild("Body")
+	assert(bodyPart, "Body not found in car")
+
+	local collision = bodyPart:FindFirstChild("Collision")
+	assert(collision, "Collision not found in Body")
+
+	local testPart = collision:FindFirstChild("body")
+	assert(testPart, "body not found in Collision")
+	assert(testPart:IsA("Part") or testPart:IsA("MeshPart"), "body is not a Part or MeshPart")
+
+	-- Record the initial color before sitting
+	local initialColor = testPart.Color
+
+	-- Make the character sit in the DriverSeat
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+	assert(humanoid, "Humanoid not found in character")
+
+	driverSeat:Sit(humanoid)
+	task.wait(0.5)
+
+	-- Verify the character is sitting
+	assert(driverSeat.Occupant == humanoid, "Failed to sit in DriverSeat")
+
+	-- Test 1: Check that color changes after sitting (within 3 seconds)
+	local colorChanged = false
+	for i = 1, 30 do
+		task.wait(0.1)
+		if testPart.Color ~= initialColor then
+			colorChanged = true
+			break
+		end
+	end
+	assert(colorChanged, "Car color did not change after driver entered")
+
+	-- Test 2: Check that color continuously changes
+	local color1 = testPart.Color
+	task.wait(0.6)  
+	local color2 = testPart.Color
+	assert(color1 ~= color2, "Car color is not continuously changing")
+
+	-- Test 3: Verify color continues changing over multiple intervals
+	local color3 = testPart.Color
+	task.wait(0.6)
+	local color4 = testPart.Color
+	assert(color3 ~= color4, "Car color stopped changing prematurely")
+
+	-- Test 4: Check that color stops changing after driver exits
+	humanoid.Sit = false
+	task.wait(1)  
+
+	local colorBeforeWait = testPart.Color
+	task.wait(1.5)  
+	local colorAfterWait = testPart.Color
+	assert(colorBeforeWait == colorAfterWait, "Car color still changing after driver exited")
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+	-- client checks not needed here
+end)
+
+return eval
+	

--- a/Evals/081_racing_car_color_change.lua
+++ b/Evals/081_racing_car_color_change.lua
@@ -72,15 +72,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "racing.rbxl",
-	expected_tool_calls = { "game_tree", "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		'game.ReplicatedStorage.Car',
-		'game.ReplicatedStorage.Car.Body.Collision.body',
-		'game.ReplicatedStorage.Car.Body.Collision.body["Color"]',
-		'game.ReplicatedStorage.Car.DriverSeat',
-		'game.ReplicatedStorage.Car.DriverSeat["Occupant"]',
-	},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/082_platformer_moving_platform_speed_up.lua
+++ b/Evals/082_platformer_moving_platform_speed_up.lua
@@ -20,22 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "platformer.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"grep_search", -- check how platform speed is scripted
-		"read_file",
-		"game_tree", -- find platform parts
-		"inspect_instance", -- get speed attribute
-		"execute_luau",
-	},
-	expected_script_instances = {
-		"game.ReplicatedStorage.Gameplay.Constants",
-		"game.ServerScriptService.Gameplay.Scripts.MovingPlatformController",
-	},
-	expected_non_script_instances = {
-		"game.Workspace.Gameplay.MovingPlatforms.MovingPlatform.speed",
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/082_platformer_moving_platform_speed_up.lua
+++ b/Evals/082_platformer_moving_platform_speed_up.lua
@@ -1,0 +1,82 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "082_platformer_moving_platform_speed_up",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make the moving platforms speed up by 5.]],
+				request_id = "s20250825_012",
+			},
+		},
+	},
+	place = "platformer.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"grep_search", -- check how platform speed is scripted
+		"read_file",
+		"game_tree", -- find platform parts
+		"inspect_instance", -- get speed attribute
+		"execute_luau",
+	},
+	expected_script_instances = {
+		"game.ReplicatedStorage.Gameplay.Constants",
+		"game.ServerScriptService.Gameplay.Scripts.MovingPlatformController",
+	},
+	expected_non_script_instances = {
+		"game.Workspace.Gameplay.MovingPlatforms.MovingPlatform.speed",
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	for _, platform in game:GetService("Workspace"):GetDescendants() do
+		if platform:IsA("Model") and platform.Name == "MovingPlatform" then
+			local speed = platform:GetAttribute("speed")
+			platform:SetAttribute("speed", speed + 5)
+		end
+	end
+	local platformTemplate = game:GetService("ServerStorage")["Template Library"]["Gameplay Objects"].MovingPlatform
+	local speed = platformTemplate:GetAttribute("speed")
+	platformTemplate:SetAttribute("speed", speed + 5)
+end
+
+eval.check_scene = function()
+	for _, platform in game:GetService("Workspace"):GetDescendants() do
+		if platform:IsA("Model") and platform.Name == "MovingPlatform" then
+			assert(platform:GetAttribute("speed") == 15, "MovingPlatform speed did not increase by 5")
+		end
+	end
+	local platformTemplate = game:GetService("ServerStorage")["Template Library"]["Gameplay Objects"].MovingPlatform
+	assert(platformTemplate:GetAttribute("speed") == 15, "MovingPlatform speed did not increase by 5")
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/083_platformer_coin_increment_down.lua
+++ b/Evals/083_platformer_coin_increment_down.lua
@@ -71,13 +71,6 @@ local eval: BaseEval = {
                 }
             },
     place = "platformer.rbxl",
-    expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-    expected_script_instances = {},
-    expected_non_script_instances = {
-        'game.ReplicatedStorage.Gameplay.Remotes.PickupCoin',
-        'game.ReplicatedStorage.Gameplay.Constants',
-        'game.Workspace.Gameplay.CoinPickups',
-    },
     runConfig = {
         serverCheck = nil,
         clientChecks = {},

--- a/Evals/083_platformer_coin_increment_down.lua
+++ b/Evals/083_platformer_coin_increment_down.lua
@@ -1,0 +1,271 @@
+--!strict
+
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _,request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName,_ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else    
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName,module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+    scenario_name = "083_platformer_coin_increment_down",
+    prompt = {
+                {
+                    {
+                        role = "user",
+                        content = [[Make the coins go down by 1 instead of up by 1 when collecting them. Don't let it go below 0.]],
+                    }
+                }
+            },
+    place = "platformer.rbxl",
+    expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
+    expected_script_instances = {},
+    expected_non_script_instances = {
+        'game.ReplicatedStorage.Gameplay.Remotes.PickupCoin',
+        'game.ReplicatedStorage.Gameplay.Constants',
+        'game.Workspace.Gameplay.CoinPickups',
+    },
+    runConfig = {
+        serverCheck = nil,
+        clientChecks = {},
+    }
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+    utils_runs.createPlayerScripts()
+end
+
+eval.reference = function()
+	local ServerScriptService = game:GetService("ServerScriptService")
+    
+    -- Create Server Script with DEBUFF Logic
+	local overrideScript = Instance.new("Script")
+	overrideScript.Name = "CoinDebuffOverride"
+
+	overrideScript.Source = [=[
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local function ensureLeaderstats(player)
+    if not player:FindFirstChild("leaderstats") then
+        local leaderstats = Instance.new("Folder")
+        leaderstats.Name = "leaderstats"
+        leaderstats.Parent = player
+        
+        local coins = Instance.new("IntValue")
+        coins.Name = "Coins"
+        -- Starting at 0 makes testing the "decrease" logic impossible without extra steps.
+        coins.Value = 10 
+        coins.Parent = leaderstats
+    end
+end
+
+Players.PlayerAdded:Connect(ensureLeaderstats)
+for _, player in ipairs(Players:GetPlayers()) do
+    ensureLeaderstats(player)
+end
+
+local Gameplay = ReplicatedStorage:WaitForChild("Gameplay")
+local Remotes = Gameplay:WaitForChild("Remotes")
+local PickupCoin = Remotes:WaitForChild("PickupCoin")
+
+local PICKUP_DISTANCE = 50 
+
+local function onPickupCoin(player, coinPart)
+    if not player.Character then return false end
+    if not coinPart then return false end
+    
+    local distance = (player.Character.PrimaryPart.Position - coinPart.Position).Magnitude
+    if distance > PICKUP_DISTANCE then return false end
+
+    local leaderstats = player:FindFirstChild("leaderstats")
+    if leaderstats then
+        local coins = leaderstats:FindFirstChild("Coins")
+        if coins then
+            -- the coin pick up works similar to a debuff now
+            -- the math.max is to ensure we don't go below 0
+            coins.Value = math.max(0, coins.Value - 1)
+            return true
+        end
+    end
+    return false
+end
+
+PickupCoin.OnServerInvoke = onPickupCoin
+]=]
+
+	overrideScript.Parent = ServerScriptService
+end
+
+eval.check_scene = function()
+
+end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+	local Players = game:GetService("Players")
+	local localPlayer = Players.LocalPlayer
+
+	-- Wait for Leaderstats and Coins
+	local leaderstats = localPlayer:WaitForChild("leaderstats", 15)
+	local coinStat = leaderstats and leaderstats:WaitForChild("Coins", 5)
+	assert(coinStat, "Coins stat not found in leaderstats")
+
+	-- Wait for Character
+	local character = localPlayer.Character or localPlayer.CharacterAdded:Wait()
+	local rootPart = character:WaitForChild("HumanoidRootPart", 10)
+
+	-- Find Coins
+	local Gameplay = workspace:WaitForChild("Gameplay", 10)
+	local CoinPickups = Gameplay and Gameplay:WaitForChild("CoinPickups", 10)
+	local coins = CoinPickups and CoinPickups:GetChildren() or {}
+	assert(#coins >= 2, "Need at least 2 coins in Workspace to test scenarios")
+	local coin1 = coins[1]
+	local coin2 = coins[2]
+
+	-- Helper: Robust Teleport to Ensure Physics Touch
+	local function teleportAndTouch(targetPos)
+		if character and character.PrimaryPart then
+			-- Teleport slightly above and force velocity down
+			character:PivotTo(CFrame.new(targetPos + Vector3.new(0, 3, 0)))
+			character.PrimaryPart.AssemblyLinearVelocity = Vector3.new(0, -10, 0)
+			task.wait(0.2)
+
+			-- Teleport directly INSIDE the coin
+			character:PivotTo(CFrame.new(targetPos))
+			character.PrimaryPart.AssemblyLinearVelocity = Vector3.zero
+			task.wait(0.2)
+
+			-- Jiggle slightly to wake physics
+			character:PivotTo(CFrame.new(targetPos + Vector3.new(0.5, 0, 0.5)))
+			task.wait(0.2)
+		end
+	end
+
+	local function teleportAway(targetPos)
+		if character and character.PrimaryPart then
+			character:PivotTo(CFrame.new(targetPos + Vector3.new(30, 20, 0)))
+			character.PrimaryPart.AssemblyLinearVelocity = Vector3.zero
+		end
+	end
+
+	-- Helper: Wait for exact value match
+	local function waitForChange(target, timeout)
+		local s = os.clock()
+		while os.clock() - s < timeout do
+			if coinStat.Value == target then return true end
+			task.wait(0.1)
+		end
+		return false
+	end
+
+	-- TEST START
+	-- I realized lately, but nevertheless did that to test what we are starting with in terms of coin is wrong
+	-- and so is wrong testing if the value reached 0 or not.
+	-- Only sensible test here is simply picking a coin and seeing if it goes -1, or stays 0. 
+	-- That's it.
+
+
+	task.wait(1)
+
+
+	local startValue = coinStat.Value
+	print("Test started with" .. tostring(startValue) .. " coins.")
+
+	teleportAway(coin1.Position)
+	task.wait(0.5)
+	teleportAndTouch(coin1.Position)
+
+	waitForChange(startValue, 3)
+
+	local valueAfterFirst = coinStat.Value
+
+	-- if the starting value was greater than 0 then check if decrease happened
+	if startValue > 0 then 
+		assert(valueAfterFirst < startValue, "Coins were expected to decrease from the original value. Started at:" .. startValue .. ", current value:" .. valueAfterFirst)
+
+		-- ensure that coin decreased exactly by 1
+		assert(valueAfterFirst == startValue - 1, "Coin didn't go down by exact 1")
+	elseif startValue == 0 then
+		assert(valueAfterFirst == 0, "Coin value should stay at 0 but got: " .. valueAfterFirst)
+	else
+		assert(false, "Starting coin value can't be less than 0")
+	end
+
+
+	teleportAway(coin2.Position)
+	task.wait(0.5)
+	teleportAndTouch(coin2.Position)
+
+	waitForChange(valueAfterFirst, 3)
+	local valueAfterSecond = coinStat.Value
+
+	if valueAfterFirst > 0 then
+		assert(valueAfterSecond == valueAfterFirst - 1, "Second coin pickup did not decrease value correctly.")
+	else
+		assert(valueAfterSecond == 0, "Coin value should stay at 0 but got: " .. valueAfterSecond)
+	end
+
+end)
+
+return eval

--- a/Evals/084_platformer_roblonk_rotate.lua
+++ b/Evals/084_platformer_roblonk_rotate.lua
@@ -20,13 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "platformer.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = { "execute_luau" },
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.Workspace.LevelArt.SkyMeshes.RoBlonk",
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/084_platformer_roblonk_rotate.lua
+++ b/Evals/084_platformer_roblonk_rotate.lua
@@ -1,0 +1,79 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "084_platformer_roblonk_rotate",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Can you rotate roblonk by 90 degrees?]],
+				request_id = "s20250825_014",
+			},
+		},
+	},
+	place = "platformer.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = { "execute_luau" },
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.Workspace.LevelArt.SkyMeshes.RoBlonk",
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+local workspace = game:GetService("Workspace")
+local startPosition = nil
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+	local roblonk = workspace.LevelArt.SkyMeshes.RoBlonk
+	startPosition = roblonk:GetPivot()
+end
+
+eval.reference = function()
+	local roblonk = workspace.LevelArt.SkyMeshes.RoBlonk
+	roblonk:PivotTo(roblonk:GetPivot() * CFrame.Angles(0, math.rad(90), 0))
+end
+
+eval.check_scene = function()
+	local workspace = game:GetService("Workspace")
+	local roblonk = workspace.LevelArt.SkyMeshes.RoBlonk
+	local newPivot = roblonk:GetPivot()
+	local transformation = startPosition:ToObjectSpace(newPivot)
+	local _, rotY, _ = transformation:ToEulerAnglesYXZ()
+	local degreesY = math.deg(rotY)
+
+	print(degreesY)
+	print(math.abs(degreesY - 90.0))
+
+	local epsilon = 0.0001
+	local isRotationCorrect = math.abs(degreesY - 90.0) < epsilon
+	assert(roblonk:GetPivot() ~= startPosition, "Roblonk was not rotated")
+	assert(isRotationCorrect, "Not rotated 90")
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/085_platformer_rosphere_hover.lua
+++ b/Evals/085_platformer_rosphere_hover.lua
@@ -20,16 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "platformer.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree", -- search for rosphere parts
-		"multi_edit",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.Workspace.LevelArt.SkyMeshes.RoSphere",
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/085_platformer_rosphere_hover.lua
+++ b/Evals/085_platformer_rosphere_hover.lua
@@ -1,0 +1,107 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "085_platformer_rosphere_hover",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Can you make the Rosphere have a hovering effect?]],
+				request_id = "s20250825_015",
+			},
+		},
+	},
+	place = "platformer.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree", -- search for rosphere parts
+		"multi_edit",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.Workspace.LevelArt.SkyMeshes.RoSphere",
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local rosphereModel = game.Workspace:FindFirstChild("LevelArt"):FindFirstChild("RoSphere")
+	local newScript = Instance.new("Script")
+	newScript.Source = [[
+local rosphereModel = script.Parent
+
+while true do
+	rosphereModel:PivotTo(rosphereModel:GetPivot() * CFrame.new(0, 1, 0))
+	wait(0.1)
+	rosphereModel:PivotTo(rosphereModel:GetPivot() * CFrame.new(0, -1, 0))
+	wait(0.1)
+end
+	]]
+	-- newScript.RunContext = Enum.RunContext.Client
+	newScript.Parent = rosphereModel
+	newScript.Enabled = false
+	task.wait()
+	newScript.Enabled = true
+end
+
+eval.check_scene = function() end
+
+eval.check_game = function()
+	local rosphereModel = game.Workspace:WaitForChild("LevelArt"):WaitForChild("RoSphere")
+	local goingDown = false
+	local goingUp = false
+	local score = 0
+	local lastY = rosphereModel:GetPivot().Position.Y
+	for i = 1, 600, 1 do
+		if math.floor(score / 2) >= 3 then
+			break
+		end
+		task.wait()
+		local currentY = rosphereModel:GetPivot().Position.Y
+		if currentY > lastY then
+			goingUp = true
+		elseif currentY < lastY then
+			goingDown = true
+		end
+		if currentY > lastY and goingDown then
+			goingDown = false
+			goingUp = true
+			score += 1
+		elseif currentY < lastY and goingUp then
+			goingUp = false
+			goingDown = true
+			score += 1
+		end
+		lastY = currentY
+	end
+	local fullHoverTimes = math.floor(score / 2)
+
+	assert(fullHoverTimes >= 3, "Roblonk is not hovering")
+end
+
+return eval

--- a/Evals/086_racing_car_jump.lua
+++ b/Evals/086_racing_car_jump.lua
@@ -75,9 +75,6 @@ local eval: BaseEval = {
                 }
             },
     place = "racing.rbxl",
-    expected_tool_calls = { "game_tree", "execute_luau", "multi_edit" },
-    expected_script_instances = {},
-    expected_non_script_instances = { "game.ReplicatedStorage.Car" },
     runConfig = {
         serverCheck = nil,
         clientChecks = {},

--- a/Evals/086_racing_car_jump.lua
+++ b/Evals/086_racing_car_jump.lua
@@ -1,0 +1,319 @@
+--!strict
+
+---------------------------------------------------------------------
+-- ROBUST DEPENDENCY LOADER (Solves for OpenEval and Assitant Plugin)
+---------------------------------------------------------------------
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _,request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName,_ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else    
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName,module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+    scenario_name = "086_racing_car_jump",
+    prompt = {
+                {
+                    {
+                        role = "user",
+                        content = [[Make it so that when a player is driving a car and jumps, the car jumps]],
+                        
+                    }
+                }
+            },
+    place = "racing.rbxl",
+    expected_tool_calls = { "game_tree", "execute_luau", "multi_edit" },
+    expected_script_instances = {},
+    expected_non_script_instances = { "game.ReplicatedStorage.Car" },
+    runConfig = {
+        serverCheck = nil,
+        clientChecks = {},
+    }
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+---------------------------------------------------------------------
+-- SETUP – Rebinding keys that could interefere with the prompt
+---------------------------------------------------------------------
+eval.setup = function()
+	-- Rebinding code
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+	local carTemplate = ReplicatedStorage:WaitForChild("Car")
+	local inputs = carTemplate:WaitForChild("Inputs")
+
+	-- Rebind handbrake off Space so it doesn't conflict with jump
+	inputs:SetAttribute("keyboardHandBrakeKeyCode", Enum.KeyCode.B)
+	inputs:SetAttribute("gamepadNitroKeyCode", Enum.KeyCode.ButtonY)
+
+	-- Load PlayerModule so VirtualInputManager key events are processed
+	utils_runs.createPlayerScripts()
+
+    local selectionService = game:GetService("Selection")
+    local selectedInstances = {}
+    for _, selection in ipairs(TableSelectionContext) do
+        for _, instance in ipairs(game:GetDescendants()) do
+            if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+                selectedInstances[#selectedInstances + 1] = instance
+                break
+            end
+        end
+    end
+    selectionService:Set(selectedInstances)
+    
+    
+end
+
+---------------------------------------------------------------------
+-- REFERENCE SOLUTION
+---------------------------------------------------------------------
+eval.reference = function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local ServerScriptService = game:GetService("ServerScriptService")
+
+	-- Create RemoteEvent for jump communication
+	local carJumpEvent = Instance.new("RemoteEvent")
+	carJumpEvent.Name = "CarJumpEvent"
+	carJumpEvent.Parent = ReplicatedStorage
+
+	-- Server Script to handle car jumping
+	local jumpServerScript = Instance.new("Script")
+	jumpServerScript.Name = "CarJumpServer"
+	jumpServerScript.Source = [[
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local carJumpEvent = ReplicatedStorage:WaitForChild("CarJumpEvent")
+
+local JUMP_COOLDOWN = 1
+local lastJumpTime = {}
+
+carJumpEvent.OnServerEvent:Connect(function(player)
+	local currentTime = tick()
+	
+	if lastJumpTime[player] and (currentTime - lastJumpTime[player]) < JUMP_COOLDOWN then
+		return
+	end
+	
+	local character = player.Character
+	if not character then return end
+	
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+	if not humanoid then return end
+	
+	local seat = humanoid.SeatPart
+	if not seat or not seat:IsA("VehicleSeat") then return end
+
+	local car = seat.Parent
+	if not car then return end
+	
+	local chassis = car:FindFirstChild("Chassis")
+	if not chassis then return end
+	
+	local bodyVelocity = Instance.new("BodyVelocity")
+	bodyVelocity.MaxForce = Vector3.new(0, math.huge, 0)
+	bodyVelocity.Velocity = Vector3.new(0, 60, 0)
+	bodyVelocity.Parent = chassis
+	
+	lastJumpTime[player] = currentTime
+	
+	task.delay(0.2, function()
+		if bodyVelocity and bodyVelocity.Parent then
+			bodyVelocity:Destroy()
+		end
+	end)
+end)
+]]
+	jumpServerScript.Parent = ServerScriptService
+
+	-- Client Script to detect jump input while driving using JumpRequest
+	local StarterPlayerScripts = game:GetService("StarterPlayer"):WaitForChild("StarterPlayerScripts")
+
+	local jumpClientScript = Instance.new("LocalScript")
+	jumpClientScript.Name = "CarJumpClient"
+	jumpClientScript.Source = [[
+local Players = game:GetService("Players")
+local UserInputService = game:GetService("UserInputService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local player = Players.LocalPlayer
+local carJumpEvent = ReplicatedStorage:WaitForChild("CarJumpEvent")
+
+local function isPlayerDriving()
+	local character = player.Character
+	if not character then return false end
+	
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+	if not humanoid then return false end
+	
+	local seat = humanoid.SeatPart
+	if seat and seat:IsA("VehicleSeat") then
+		return true
+	end
+	
+	return false
+end
+
+UserInputService.JumpRequest:Connect(function()
+	if true then
+		carJumpEvent:FireServer()
+	end
+end)
+]]
+	jumpClientScript.Parent = StarterPlayerScripts
+end
+
+---------------------------------------------------------------------
+-- CHECK SCENE – Empty, unneceessary for this prompt
+---------------------------------------------------------------------
+eval.check_scene = function()
+end
+
+---------------------------------------------------------------------
+-- SERVER CHECKS – Used To Spawn A Car For Client Testing
+---------------------------------------------------------------------
+eval.runConfig.serverCheck = function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local Workspace = game:GetService("Workspace")
+
+	local carTemplate = ReplicatedStorage:WaitForChild("Car", 10)
+	-- Server Check 1: Car template integrity
+	assert(carTemplate, "Car template not found in ReplicatedStorage")
+
+	local car = carTemplate:Clone()
+	car.Name = "Car"
+	car.Parent = Workspace
+
+	local spawn = Workspace:WaitForChild("SpawnLocation", 10)
+
+	-- Server Check 2: Spawn location integrity
+	assert(spawn, "SpawnLocation not found")
+
+	car:PivotTo(spawn:GetPivot() * CFrame.new(0, 10, -10))
+end
+
+---------------------------------------------------------------------
+-- CLIENT CHECKS – Car Jump Functionality Testing
+---------------------------------------------------------------------
+table.insert(eval.runConfig.clientChecks, function()
+	local Players = game:GetService("Players")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+	local car = Workspace:WaitForChild("Car", 10)
+	-- Client Check 1: Car integrity
+	assert(car, "Car not found in Workspace")
+
+	local chassis = car:WaitForChild("Chassis", 10)
+	-- Client Check 2: Chassis integrity
+	assert(chassis, "Chassis not found in Car")
+
+	local seat = car:WaitForChild("DriverSeat", 10)
+	-- Client Check 3: DriverSeat integrity
+	assert(seat, "DriverSeat not found in Car")
+
+	-- Stabilize character on open-eval
+	task.wait(3)
+
+	local player = Players.LocalPlayer
+	local character = player.Character or player.CharacterAdded:Wait()
+	local humanoid = character:WaitForChild("Humanoid", 10)
+
+	-- Clone PlayerModule into PlayerScripts so virtual key events work
+	utils_runs.loadPlayerScripts()
+
+	seat:Sit(humanoid)
+
+	local t1 = os.clock()
+	while humanoid.SeatPart == nil and os.clock() - t1 < 10 do
+		task.wait(0.05)
+	end
+
+	-- Client Check 4: Humanoid seated
+	assert(humanoid.SeatPart, "Player not seated on client")
+
+	local phase = 0
+
+	-- Simulate Space keypress to trigger jump
+	utils_runs.sendKeyEvent(true, Enum.KeyCode.Space)
+	task.wait(0.05)
+	utils_runs.sendKeyEvent(false, Enum.KeyCode.Space)
+
+	-- Monitor car's vertical velocity to confirm jump
+	local startTime = os.time()
+	while os.time() - startTime < 10 do 
+		task.wait(0.2)
+		local velocity = chassis.AssemblyLinearVelocity.Y
+		if (phase == 0) and (velocity > 10) then
+			phase = 1
+		elseif (phase == 1) and (velocity < 0) then
+			phase = 2
+		elseif (phase == 2) and (math.abs(velocity) < 0.1) then
+			phase = 3
+		elseif (phase == 3) and (math.abs(velocity) < 0.1) then
+			phase = 4
+			break
+		end
+	end
+
+	-- Client Check 5: Jump verification
+	assert(phase == 4, "Car did not complete a jump, only reaching phase " .. tostring(phase) .. "/4")
+
+	-- Client Check 6: Humanoid still seated after jump
+	assert(seat.Occupant == humanoid, "Humanoid is no longer occupying the DriverSeat after jump")
+
+end)
+
+return eval

--- a/Evals/088_surburban_garage_door_speed_up.lua
+++ b/Evals/088_surburban_garage_door_speed_up.lua
@@ -20,23 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "surburban.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"grep_search",
-		"read_file", -- check how garage door speed is scripted
-		"game_tree", -- find all garage doors
-		"inspect_instance", -- find attributes for speed
-		"execute_luau",
-	},
-	expected_script_instances = {
-		"game.Workspace.GarageBuilding.PhysicsGarageDoor.DoorOpener.GarageDoorScript",
-		'game.Workspace["Urban House"].Garage.PhysicsGarageDoor.DoorOpener.GarageDoorScript',
-	},
-	expected_non_script_instances = {
-		"game.Workspace.GarageBuilding.PhysicsGarageDoor.Door.Base.BodyGyro",
-		'game.Workspace["Urban House"].Garage.PhysicsGarageDoor.Door.Base.BodyGyro',
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/088_surburban_garage_door_speed_up.lua
+++ b/Evals/088_surburban_garage_door_speed_up.lua
@@ -1,0 +1,87 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "088_surburban_garage_door_speed_up",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Double the speed of the garage doors opening.]],
+				request_id = "s20250825_018",
+			},
+		},
+	},
+	place = "surburban.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"grep_search",
+		"read_file", -- check how garage door speed is scripted
+		"game_tree", -- find all garage doors
+		"inspect_instance", -- find attributes for speed
+		"execute_luau",
+	},
+	expected_script_instances = {
+		"game.Workspace.GarageBuilding.PhysicsGarageDoor.DoorOpener.GarageDoorScript",
+		'game.Workspace["Urban House"].Garage.PhysicsGarageDoor.DoorOpener.GarageDoorScript',
+	},
+	expected_non_script_instances = {
+		"game.Workspace.GarageBuilding.PhysicsGarageDoor.Door.Base.BodyGyro",
+		'game.Workspace["Urban House"].Garage.PhysicsGarageDoor.Door.Base.BodyGyro',
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local descendants = workspace:GetDescendants()
+	for _, obj in descendants do
+		if obj:IsA("Folder") and obj.Name == "PhysicsGarageDoor" then
+			for _, desc in obj:GetDescendants() do
+				if desc:IsA("BodyGyro") then
+					desc.P = 400
+				end
+			end
+		end
+	end
+end
+
+eval.check_scene = function()
+	local descendants = workspace:GetDescendants()
+	for _, obj in descendants do
+		if obj:IsA("Folder") and obj.Name == "PhysicsGarageDoor" then
+			for _, desc in obj:GetDescendants() do
+				if desc:IsA("BodyGyro") then
+					assert(desc.P == 400, "Garage door speed has not doubled")
+				end
+			end
+		end
+	end
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/089_fps_box_fling_harder.lua
+++ b/Evals/089_fps_box_fling_harder.lua
@@ -20,18 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "fps_system.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree",
-		"inspect_instance", -- find weapons and get force attributes
-		"execute_luau",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.StarterPack.AutoBlaster.unanchoredImpulseForce",
-		"game.StarterPack.Blaster.unanchoredImpulseForce",
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/089_fps_box_fling_harder.lua
+++ b/Evals/089_fps_box_fling_harder.lua
@@ -1,0 +1,85 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "089_fps_box_fling_harder",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make the boxes fling harder when you shoot them.]],
+				request_id = "s20250825_019",
+			},
+		},
+	},
+	place = "fps_system.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree",
+		"inspect_instance", -- find weapons and get force attributes
+		"execute_luau",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.StarterPack.AutoBlaster.unanchoredImpulseForce",
+		"game.StarterPack.Blaster.unanchoredImpulseForce",
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+local StarterPack = game:GetService("StarterPack")
+local Defaults = {
+	Blaster = 5,
+	AutoBlaster = 2,
+}
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+	local AutoBlaster = StarterPack:FindFirstChild("AutoBlaster")
+	local Blaster = StarterPack:FindFirstChild("Blaster")
+
+	AutoBlaster:SetAttribute("unanchoredImpulseForce", Defaults.AutoBlaster)
+	Blaster:SetAttribute("unanchoredImpulseForce", Defaults.Blaster)
+end
+
+eval.reference = function()
+	local AutoBlaster = StarterPack.AutoBlaster
+	local Blaster = StarterPack:FindFirstChild("Blaster")
+	AutoBlaster:SetAttribute("unanchoredImpulseForce", Defaults.AutoBlaster * 2)
+	Blaster:SetAttribute("unanchoredImpulseForce", Defaults.Blaster * 2)
+end
+
+eval.check_scene = function()
+	local AutoBlaster = StarterPack.AutoBlaster
+	local Blaster = StarterPack:FindFirstChild("Blaster")
+	local autoBlasterForce = AutoBlaster:GetAttribute("unanchoredImpulseForce")
+	local blasterForce = Blaster:GetAttribute("unanchoredImpulseForce")
+
+	local validIncreases = autoBlasterForce >= Defaults.AutoBlaster * 1.5 and blasterForce >= Defaults.Blaster * 1.5
+	assert(validIncreases, "One or more blasters did not have valid force increases!")
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/090_fps_display_target_damage_ui.lua
+++ b/Evals/090_fps_display_target_damage_ui.lua
@@ -1,0 +1,390 @@
+--!strict
+
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _,request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName,_ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else    
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName,module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+    scenario_name = "pilot_023",
+    prompt = {
+                {
+                    {
+                        role = "user",
+                        content = [[Make the targets display the damage with a UI after shooting the targets.]],
+                        request_id = "pilot_023"
+                    }
+                }
+            },
+    place = "fps_system.rbxl",
+    expected_tool_calls = { "game_tree", "execute_luau", "multi_edit" },
+    expected_script_instances = {
+        'game.ServerScriptService.Targets',
+        'game.ServerScriptService.Blaster.Scripts.Blaster'
+    },
+    expected_non_script_instances = {
+        'game.ServerScriptService.Blaster.Events.Tagged'
+    },
+    runConfig = {
+        serverCheck = nil,
+        clientChecks = {},
+    }
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+local TEST_REMOTE_EVENT_NAME = "EvalTestDamageEvent"
+
+eval.setup = function()
+    utils_runs.createPlayerScripts()
+
+    -- Create RemoteEvent for test communication between server and client
+    local testRemoteEvent = Instance.new("RemoteEvent")
+    testRemoteEvent.Name = TEST_REMOTE_EVENT_NAME
+    testRemoteEvent.Parent = game:GetService("ReplicatedStorage")
+end
+
+eval.reference = function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local ServerScriptService = game:GetService("ServerScriptService")
+	local StarterPlayer = game:GetService("StarterPlayer")
+	local StarterPlayerScripts = StarterPlayer:FindFirstChild("StarterPlayerScripts")
+
+	local damageDisplayEvent = Instance.new("RemoteEvent")
+	damageDisplayEvent.Name = "DamageDisplayEvent"
+	damageDisplayEvent.Parent = ReplicatedStorage
+    
+	-- local script for client-side damage display in UI
+	local damageDisplayLocalScript = Instance.new("LocalScript")
+	damageDisplayLocalScript.Name = "DamageDisplayHandler"
+	damageDisplayLocalScript.Source = [[
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local Players = game:GetService("Players")
+	local TweenService = game:GetService("TweenService")
+
+	local player = Players.LocalPlayer
+	local playerGui = player:WaitForChild("PlayerGui")
+
+	local damageGui = Instance.new("ScreenGui")
+	damageGui.Name = "DamageDisplayGui"
+	damageGui.Parent = playerGui
+
+	local damageDisplayEvent = ReplicatedStorage:WaitForChild("DamageDisplayEvent")
+
+	-- display damage at world position function
+	local function displayDamage(targetPosition, damageAmount)
+		local camera = workspace.CurrentCamera
+		if not camera then return end
+
+		-- convert world pos
+		local screenPosition, onScreen = camera:WorldToScreenPoint(targetPosition)
+		if not onScreen then return end
+
+		-- create damage label
+		local damageLabel = Instance.new("TextLabel")
+		damageLabel.Name = "DamageNumber"
+		damageLabel.Size = UDim2.new(0, 100, 0, 50)
+		damageLabel.Position = UDim2.new(0, screenPosition.X - 50, 0, screenPosition.Y - 25)
+		damageLabel.BackgroundTransparency = 1
+		damageLabel.Text = tostring(damageAmount)
+		damageLabel.TextColor3 = Color3.new(1, 0.2, 0.2)
+		damageLabel.TextStrokeTransparency = 0.5
+		damageLabel.TextStrokeColor3 = Color3.new(0, 0, 0)
+		damageLabel.Font = Enum.Font.GothamBold
+		damageLabel.TextSize = 24
+		damageLabel.TextScaled = false
+		damageLabel.Parent = damageGui
+
+		-- animate damage number (tween float up and fade out)
+		local tweenInfo = TweenInfo.new(1, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+		local endPosition = UDim2.new(0, screenPosition.X - 50, 0, screenPosition.Y - 75)
+
+		local moveTween = TweenService:Create(damageLabel, tweenInfo, {
+			Position = endPosition,
+			TextTransparency = 1,
+			TextStrokeTransparency = 1
+		})
+
+		moveTween:Play()
+		moveTween.Completed:Connect(function()
+			damageLabel:Destroy()
+		end)
+	end
+
+	-- listen for damage display events from server
+	damageDisplayEvent.OnClientEvent:Connect(function(targetPosition, damageAmount)
+		displayDamage(targetPosition, damageAmount)
+	end)
+	]]
+
+	damageDisplayLocalScript.Parent = StarterPlayerScripts
+
+	-- server script to detect damage and fire damage events
+	local damageServerScript = Instance.new("Script")
+	damageServerScript.Name = "DamageDisplayServer"
+	damageServerScript.Source = [[
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local Players = game:GetService("Players")
+
+	local damageDisplayEvent = ReplicatedStorage:WaitForChild("DamageDisplayEvent")
+
+	-- detect damage via humanoid health changes
+	local function setupDamageDetection()
+		for _, target in ipairs(workspace:GetDescendants()) do
+			-- skip non models
+			if not target:isA("Model") then continue end
+
+			local humanoid = target:FindFirstChild("Humanoid")
+			-- skip non humanoids
+			if not humanoid then continue end
+
+			local lastHealth = humanoid.Health
+			humanoid.HealthChanged:Connect(function(newHealth)
+				local damage = lastHealth - newHealth
+				if damage > 0 then
+					local targetPosition = target:GetPivot().Position
+					for _, player in ipairs(Players:GetPlayers()) do
+						damageDisplayEvent:FireClient(player, targetPosition, math.floor(damage))
+					end
+				end
+				lastHealth = newHealth
+			end)
+		end
+	end
+
+	-- run setup
+	setupDamageDetection()
+	]]
+
+	damageServerScript.Parent = ServerScriptService
+
+end
+
+eval.check_scene = function()    
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+    print("[ServerCheck] Initializing...")
+    local ReplicatedStorage = game:GetService("ReplicatedStorage")
+    local Players = game:GetService("Players")
+
+    local testRemoteEvent = ReplicatedStorage:FindFirstChild(TEST_REMOTE_EVENT_NAME) :: RemoteEvent
+    assert(testRemoteEvent, "Test RemoteEvent not found in ReplicatedStorage")
+
+    -- wait for player
+    print("[ServerCheck] Waiting for player...")
+    local player = Players:GetPlayers()[1] or Players.PlayerAdded:Wait()
+    assert(player, "No player found")
+    print("[ServerCheck] Player found:", player.Name)
+
+    -- find targets with Humanoids
+    local targets = {}
+    for _, descendant in ipairs(workspace:GetDescendants()) do
+        if descendant:IsA("Model") and descendant.Name ~= player.Name then
+            local humanoid = descendant:FindFirstChild("Humanoid")
+            if humanoid then
+                table.insert(targets, descendant)
+            end
+        end
+    end
+    print("[ServerCheck] Found", #targets, "targets with Humanoids")
+    assert(#targets >= 2, "At least two targets with Humanoids should exist in workspace")
+
+    -- set up listener for client ready signal
+    local clientReadyEvent = Instance.new("BindableEvent")
+    local clientReady = false
+    testRemoteEvent.OnServerEvent:Connect(function(fromPlayer, message)
+        if fromPlayer == player and message == "CLIENT_READY" then
+            clientReady = true
+            clientReadyEvent:Fire()
+        end
+    end)
+
+    -- wait for client to be ready
+    print("[ServerCheck] Waiting for client to be ready...")
+    if not clientReady then
+        clientReadyEvent.Event:Wait()
+    end
+    print("[ServerCheck] Client is ready, starting tests...")
+
+    -- Test 1: deal 37 damage from server (unique number that won't match ammo counts)
+    local target1 = targets[1]
+    local humanoid1 = target1:FindFirstChild("Humanoid")
+    humanoid1:TakeDamage(37)
+
+    -- notify client to check for damage indicator
+    testRemoteEvent:FireClient(player, "CHECK_DAMAGE", 37)
+
+    -- wait for client confirmation
+    local checkDoneEvent = Instance.new("BindableEvent")
+    local checkResult = nil
+    testRemoteEvent.OnServerEvent:Connect(function(fromPlayer, message, result)
+        if fromPlayer == player and message == "CHECK_DONE" then
+            checkResult = result
+            checkDoneEvent:Fire()
+        end
+    end)
+
+    checkDoneEvent.Event:Wait()
+    assert(checkResult == true, "Client failed to find '37' damage indicator")
+    print("[ServerCheck] Test 1 PASSED: Found '37' damage indicator")
+    task.wait(1.2)
+
+    -- Test 2: deal 43 damage from server
+    local target2 = targets[2]
+    local humanoid2 = target2:FindFirstChild("Humanoid")
+    humanoid2:TakeDamage(43)
+
+    -- notify client to check for damage indicator
+    testRemoteEvent:FireClient(player, "CHECK_DAMAGE", 43)
+
+    -- wait for client confirmation
+    local checkDoneEvent2 = Instance.new("BindableEvent")
+    local checkResult2 = nil
+    testRemoteEvent.OnServerEvent:Connect(function(fromPlayer, message, result)
+        if fromPlayer == player and message == "CHECK_DONE" then
+            checkResult2 = result
+            checkDoneEvent2:Fire()
+        end
+    end)
+
+    checkDoneEvent2.Event:Wait()
+    assert(checkResult2 == true, "Client failed to find '43' damage indicator")
+    print("[ServerCheck] Test 2 PASSED: Found '43' damage indicator")
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+    print("[ClientCheck] Initializing...")
+    local Players = game:GetService("Players")
+    local ReplicatedStorage = game:GetService("ReplicatedStorage")
+    local player = Players.LocalPlayer
+    local playerGui = player:WaitForChild("PlayerGui", 5)
+
+    -- get test remote event
+    local testRemoteEvent = ReplicatedStorage:WaitForChild(TEST_REMOTE_EVENT_NAME, 5) :: RemoteEvent
+    assert(testRemoteEvent, "Test RemoteEvent not found in ReplicatedStorage")
+    print("[ClientCheck] Test RemoteEvent found")
+
+    -- helper function to find damage indicator containing the damage amount 
+	-- using unique damage amounts to avoid false positives with ammo counts
+    local function findDamageIndicator(damageString)
+        -- Check PlayerGui (ScreenGui approach)
+        for _, gui in ipairs(playerGui:GetDescendants()) do
+            if gui:IsA("TextLabel") and gui.Text then
+                local text = gui.Text
+                -- check if text contains the damage number
+                if string.find(text, damageString) then
+                    return true
+                end
+            end
+        end
+        -- check workspace (BillboardGui approach)
+        for _, gui in ipairs(workspace:GetDescendants()) do
+            if gui:IsA("BillboardGui") then
+                for _, child in ipairs(gui:GetDescendants()) do
+                    if child:IsA("TextLabel") and child.Text then
+                        local text = child.Text
+                        if string.find(text, damageString) then
+                            return true
+                        end
+                    end
+                end
+            end
+        end
+        return false
+    end
+
+    -- helper function to wait for CHECK_DAMAGE command and verify indicator
+    local function waitForDamageCheckCommand()
+        local command, damageAmount = testRemoteEvent.OnClientEvent:Wait()
+
+        if command == "CHECK_DAMAGE" then
+            task.wait(0.3)
+            local damageString = tostring(damageAmount)
+            local found = findDamageIndicator(damageString)
+            testRemoteEvent:FireServer("CHECK_DONE", found)
+            return found
+        end
+
+        return false
+    end
+
+    -- signal server that client is ready
+    print("[ClientCheck] Signaling server that client is ready...")
+    testRemoteEvent:FireServer("CLIENT_READY")
+
+    -- Test 1: wait for server to deal 37 damage and check
+    print("[ClientCheck] Waiting for Test 1 (37 damage)...")
+    local result1 = waitForDamageCheckCommand()
+    assert(result1, "Test 1: Failed to find damage indicator for 37 damage")
+    print("[ClientCheck] Test 1 PASSED: Found '37' damage indicator")
+
+    -- Test 2: wait for server to deal 43 damage and check
+    print("[ClientCheck] Waiting for Test 2 (43 damage)...")
+    local result2 = waitForDamageCheckCommand()
+    assert(result2, "Test 2: Failed to find damage indicator for 43 damage")
+    print("[ClientCheck] Test 2 PASSED: Found '43' damage indicator")
+end)
+
+return eval

--- a/Evals/090_fps_display_target_damage_ui.lua
+++ b/Evals/090_fps_display_target_damage_ui.lua
@@ -72,14 +72,6 @@ local eval: BaseEval = {
                 }
             },
     place = "fps_system.rbxl",
-    expected_tool_calls = { "game_tree", "execute_luau", "multi_edit" },
-    expected_script_instances = {
-        'game.ServerScriptService.Targets',
-        'game.ServerScriptService.Blaster.Scripts.Blaster'
-    },
-    expected_non_script_instances = {
-        'game.ServerScriptService.Blaster.Events.Tagged'
-    },
     runConfig = {
         serverCheck = nil,
         clientChecks = {},

--- a/Evals/091_surburban_fix_grass_in_house.lua
+++ b/Evals/091_surburban_fix_grass_in_house.lua
@@ -1,0 +1,102 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "091_surburban_fix_grass_in_house",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Fix the grass in the floor of the house named 'Double Story Urban House' which shouldnt be there]],
+				request_id = "s20250825_021",
+			},
+		},
+	},
+	place = "surburban.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree", -- understand house, terrain
+		"inspect_instance", -- understand floor
+		"execute_luau",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		'game.Workspace["Double Story Urban House"].HouseFrame.FrontPorch',
+		'game.Workspace["Double Story Urban House"].LowerLevel.RoomFrames',
+		'game.Workspace["Double Story Urban House"].UpperLevel.RoomFrames',
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local terrain = game:GetService("Workspace").Terrain
+	local house = game:GetService("Workspace")["Double Story Urban House"]
+	local region3List = {}
+	for _, floor in house:GetDescendants() do
+		if floor:IsA("BasePart") then
+			if floor.Name == "Floor" or floor.Parent.Name == "FrontPorch" then
+				local sizeOffset = Vector3.new(3 + floor.Size.X / 2, 10, 3 + floor.Size.Z / 2)
+				local region3 = Region3.new(floor.Position - sizeOffset, floor.Position + sizeOffset):ExpandToGrid(4)
+				table.insert(region3List, region3)
+			end
+		end
+	end
+	for _, region3 in region3List do
+		terrain:ReplaceMaterial(region3, 4, Enum.Material.Grass, Enum.Material.LeafyGrass)
+	end
+end
+
+eval.check_scene = function()
+	local terrain = game:GetService("Workspace").Terrain
+	local house = game:GetService("Workspace")["Double Story Urban House"]
+	local region3List = {}
+	for _, floor in house:GetDescendants() do
+		if floor:IsA("BasePart") then
+			if floor.Name == "Floor" or floor.Parent.Name == "FrontPorch" then
+				local sizeOffset = Vector3.new(2 + floor.Size.X / 2, 6, 2 + floor.Size.Z / 2)
+				local region3 = Region3.new(floor.Position - sizeOffset, floor.Position + sizeOffset):ExpandToGrid(4)
+				table.insert(region3List, region3)
+			end
+		end
+	end
+	for _, region3 in region3List do
+		local materials = terrain:ReadVoxels(region3, 4, Enum.Material.Grass, Enum.Material.LeafyGrass)
+		for _, info in materials do
+			if type(info) ~= "vector" then
+				for _, voxelList in info do
+					for _, voxel in voxelList do
+						assert(voxel ~= Enum.Material.Grass, "Grass still found under house")
+					end
+				end
+			end
+		end
+	end
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/091_surburban_fix_grass_in_house.lua
+++ b/Evals/091_surburban_fix_grass_in_house.lua
@@ -20,19 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "surburban.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree", -- understand house, terrain
-		"inspect_instance", -- understand floor
-		"execute_luau",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		'game.Workspace["Double Story Urban House"].HouseFrame.FrontPorch',
-		'game.Workspace["Double Story Urban House"].LowerLevel.RoomFrames',
-		'game.Workspace["Double Story Urban House"].UpperLevel.RoomFrames',
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/092_fps_shoot_ground_bounce.lua
+++ b/Evals/092_fps_shoot_ground_bounce.lua
@@ -72,9 +72,6 @@ local eval: BaseEval = {
                 }
             },
     place = "fps_system.rbxl",
-    expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-    expected_script_instances = { 'game.ReplicatedStorage.Blaster.Scripts.BlasterController' },
-    expected_non_script_instances = { 'game.StarterPack.Blaster' },
     runConfig = {
         serverCheck = nil,
         clientChecks = {},

--- a/Evals/092_fps_shoot_ground_bounce.lua
+++ b/Evals/092_fps_shoot_ground_bounce.lua
@@ -1,0 +1,354 @@
+--!strict
+
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _,request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName,_ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else    
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName,module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+    scenario_name = "pilot_024",
+    prompt = {
+                {
+                    {
+                        role = "user",
+                        content = [[Make the player bounce in the air when shooting the ground within 5 studs of the player.]],
+                        request_id = "pilot_024"
+                    }
+                }
+            },
+    place = "fps_system.rbxl",
+    expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
+    expected_script_instances = { 'game.ReplicatedStorage.Blaster.Scripts.BlasterController' },
+    expected_non_script_instances = { 'game.StarterPack.Blaster' },
+    runConfig = {
+        serverCheck = nil,
+        clientChecks = {},
+    }
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+    utils_runs.createPlayerScripts()
+    
+end
+
+eval.reference = function()
+	local StarterPlayer = game:GetService("StarterPlayer")
+    local StarterPlayerScripts = StarterPlayer:FindFirstChild("StarterPlayerScripts")
+
+    local bounceScript = Instance.new("LocalScript")
+    bounceScript.Name = "GroundBounce"
+    bounceScript.Source = [[
+        local Players = game:GetService("Players")
+        local player = Players.LocalPlayer
+        local camera = workspace.CurrentCamera
+
+        local BOUNCE_DISTANCE = 5
+        local BOUNCE_VELOCITY = 50
+
+        local function checkBounce()
+            local character = player.Character
+            if not character then return end
+
+            local hrp = character:FindFirstChild("HumanoidRootPart")
+            if not hrp then return end
+
+            local origin = camera.CFrame.Position
+            local direction = camera.CFrame.LookVector * 1000
+
+            local params = RaycastParams.new()
+            params.FilterDescendantsInstances = {character}
+            params.FilterType = Enum.RaycastFilterType.Exclude
+
+            local result = workspace:Raycast(origin, direction, params)
+            if not result then return end
+
+            local isGround = result.Normal.Y > 0.5
+            local distance = (result.Position - hrp.Position).Magnitude
+
+            if isGround and distance <= BOUNCE_DISTANCE then
+                hrp.AssemblyLinearVelocity = Vector3.new(
+                    hrp.AssemblyLinearVelocity.X,
+                    BOUNCE_VELOCITY,
+                    hrp.AssemblyLinearVelocity.Z
+                )
+            end
+        end
+
+        local function setupCharacter(character)
+            for _, child in character:GetChildren() do
+                if child:IsA("Tool") then
+                    child.Activated:Connect(checkBounce)
+                end
+            end
+            character.ChildAdded:Connect(function(child)
+                if child:IsA("Tool") then
+                    child.Activated:Connect(checkBounce)
+                end
+            end)
+        end
+
+        if player.Character then
+            setupCharacter(player.Character)
+        end
+        player.CharacterAdded:Connect(setupCharacter)
+    ]]
+
+    bounceScript.Parent = StarterPlayerScripts
+end
+
+eval.check_scene = function()
+    
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+    
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+    local Workspace = game:GetService("Workspace")
+    local BOUNCE_DISTANCE = 5
+    local MIN_BOUNCE_HEIGHT = 1
+
+    local flatGroundPos = Vector3.new(-16.198, 0, 16.79)
+    local rampPos = Vector3.new(-1.096, 2.131, 40.533)
+    local wallPos = Vector3.new(28.669, 0, 1.393)
+    local wallOrientation = CFrame.Angles(0, math.rad(-85), 0)
+    local roofPos = Vector3.new(-14, 7, 16.79)
+
+    local Players = game:GetService("Players")
+    local LocalPlayer = Players.LocalPlayer
+    local character = LocalPlayer.Character or LocalPlayer.CharacterAdded:Wait()
+    local humanoidRootPart = character:WaitForChild("HumanoidRootPart")
+    local humanoid = character:WaitForChild("Humanoid")
+    local camera = Workspace.CurrentCamera
+
+    local rayParams = RaycastParams.new()
+    rayParams.FilterDescendantsInstances = {character}
+    rayParams.FilterType = Enum.RaycastFilterType.Exclude
+
+    local groundCheck = Workspace:Raycast(humanoidRootPart.Position, Vector3.new(0, -50, 0), rayParams)
+    local playerHeight = groundCheck and (humanoidRootPart.Position.Y - groundCheck.Position.Y) or 3
+
+    local function getEquippedTool()
+        for _, child in character:GetChildren() do
+            if child:IsA("Tool") then return child end
+        end
+        return nil
+    end
+
+    local function isGrounded()
+        local result = Workspace:Raycast(humanoidRootPart.Position, Vector3.new(0, -4, 0), rayParams)
+        return result ~= nil and math.abs(humanoidRootPart.AssemblyLinearVelocity.Y) < 1
+    end
+
+    local function waitForGrounded()
+        while not isGrounded() do task.wait(0.05) end
+        task.wait(0.1)
+    end
+
+    local function checkForBounce()
+        local maxHeight = character:GetPivot().Position.Y
+        task.wait(0.1)
+        while not isGrounded() do
+            task.wait(0.02)
+            maxHeight = math.max(maxHeight, character:GetPivot().Position.Y)
+        end
+        task.wait(0.1)
+        return maxHeight - character:GetPivot().Position.Y
+    end
+
+    local function teleportTo(position, orientation)
+        local targetCFrame = CFrame.new(position) * CFrame.new(0, playerHeight, 0)
+        if orientation then
+            targetCFrame = targetCFrame * orientation
+        end
+        humanoidRootPart.CFrame = targetCFrame
+        waitForGrounded()
+    end
+
+    -- Fixed camera positioning: place camera above/behind player
+    local function lookAt(target, isOffset)
+        local lookTarget = target
+        if isOffset then
+            lookTarget = humanoidRootPart.Position + target
+        end
+        local camPos = humanoidRootPart.Position + Vector3.new(0, 2, 2)
+        camera.CFrame = CFrame.new(camPos, lookTarget)
+        task.wait(0.1)
+    end
+
+    local function activateTool()
+        local tool = getEquippedTool()
+        if tool then
+            tool:Activate()
+            task.wait(0.1)
+            tool:Deactivate()
+        end
+    end
+
+    local function getAllTools()
+        local tools = {}
+        local backpack = LocalPlayer:FindFirstChild("Backpack")
+        if backpack then
+            for _, item in backpack:GetChildren() do
+                if item:IsA("Tool") then table.insert(tools, item) end
+            end
+        end
+        local equipped = getEquippedTool()
+        if equipped then table.insert(tools, equipped) end
+        return tools
+    end
+
+    -- Wait for LocalScript to set up connections
+    task.wait(2)
+    local tools = getAllTools()
+
+    -- Test 1: Bounce with all tools
+    for _, tool in tools do
+        humanoid:EquipTool(tool)
+        task.wait(0.5)
+        -- Aim at ground directly below player
+        local groundY = groundCheck and groundCheck.Position.Y or (humanoidRootPart.Position.Y - 3)
+        lookAt(Vector3.new(humanoidRootPart.Position.X, groundY, humanoidRootPart.Position.Z), false)
+        activateTool()
+        local height = checkForBounce()
+        assert(height > MIN_BOUNCE_HEIGHT, "No bounce with " .. tool.Name)
+        print("[PASS] Bounce with " .. tool.Name)
+    end
+
+    if tools[1] then
+        humanoid:EquipTool(tools[1])
+        task.wait(0.5)
+    end
+
+    -- Test 2: Ramp bounce
+    teleportTo(rampPos)
+    local groundY = groundCheck and groundCheck.Position.Y or (humanoidRootPart.Position.Y - 3)
+    lookAt(Vector3.new(humanoidRootPart.Position.X, groundY, humanoidRootPart.Position.Z), false)
+    activateTool()
+    local height = checkForBounce()
+    assert(height > MIN_BOUNCE_HEIGHT, "No bounce on ramp")
+    print("[PASS] Ramp surface bounce")
+
+    -- Test 3: Beyond 5 studs - no bounce
+    teleportTo(flatGroundPos)
+    task.wait(0.5)
+    local ground = Workspace:Raycast(humanoidRootPart.Position, Vector3.new(0, -50, 0), rayParams)
+    groundY = ground and ground.Position.Y or 0
+    local h = BOUNCE_DISTANCE + 0.1
+    local groundTarget = Vector3.new(
+        humanoidRootPart.Position.X - h * math.cos(math.rad(45)),
+        groundY,
+        humanoidRootPart.Position.Z - h * math.sin(math.rad(45))
+    )
+    lookAt(groundTarget, false)
+    activateTool()
+    height = checkForBounce()
+    assert(height < MIN_BOUNCE_HEIGHT, "Bounced beyond 5 studs")
+    print("[PASS] Beyond 5 studs no bounce")
+
+    -- Test 4: Wall - no bounce
+    teleportTo(wallPos, wallOrientation)
+    lookAt(wallOrientation.LookVector * 5, true)
+    activateTool()
+    height = checkForBounce()
+    assert(height < MIN_BOUNCE_HEIGHT, "Bounced on wall")
+    print("[PASS] Wall no bounce")
+
+    -- Test 5: Roof - no bounce (non-collidable ceiling within range)
+    teleportTo(flatGroundPos)
+    task.wait(0.5)
+
+    -- Create a non-collidable roof above the player within bounce range
+    local roof = Instance.new("Part")
+    roof.Name = "TestRoof"
+    roof.Size = Vector3.new(10, 1, 10)
+    roof.Position = humanoidRootPart.Position + Vector3.new(0, 3, 0)
+    roof.Anchored = true
+    roof.CanCollide = false
+    roof.Transparency = 0.5
+    roof.Parent = Workspace
+
+    task.wait(0.1)
+    lookAt(roof.Position, false)
+    activateTool()
+    height = checkForBounce()
+
+	roof:Destroy()
+    assert(height < MIN_BOUNCE_HEIGHT, "Bounced on roof/ceiling")
+    print("[PASS] Roof no bounce")
+
+    -- Test 6: Sky - no bounce
+    lookAt(Vector3.new(0, 100, 0), true)
+    activateTool()
+    height = checkForBounce()
+    assert(height < MIN_BOUNCE_HEIGHT, "Bounced shooting sky")
+    print("[PASS] Sky no bounce")
+
+    print("[PASS] All tests passed")
+end)
+
+return eval

--- a/Evals/093_surburban_jeep_in_every_garage.lua
+++ b/Evals/093_surburban_jeep_in_every_garage.lua
@@ -20,20 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "surburban.rbxl",
-	tool = nil,
-	tags = {},
-	difficulty = "easy",
-	expected_tool_calls = {
-		"game_tree", -- locate jeep and garages
-		"inspect_instance", -- locate garage frames to place jeep in
-		"execute_luau",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.Workspace.Jeep",
-		"game.Workspace.GarageBuilding",
-		'game.Workspace["Urban House"].Body.GarageFrame',
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/093_surburban_jeep_in_every_garage.lua
+++ b/Evals/093_surburban_jeep_in_every_garage.lua
@@ -1,0 +1,140 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "093_surburban_jeep_in_every_garage",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Place a copy of the jeep in every garage.]],
+				request_id = "s20250825_023",
+			},
+		},
+	},
+	place = "surburban.rbxl",
+	tool = nil,
+	tags = {},
+	difficulty = "easy",
+	expected_tool_calls = {
+		"game_tree", -- locate jeep and garages
+		"inspect_instance", -- locate garage frames to place jeep in
+		"execute_luau",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.Workspace.Jeep",
+		"game.Workspace.GarageBuilding",
+		'game.Workspace["Urban House"].Body.GarageFrame',
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+local Workspace = game:GetService("Workspace")
+local InitalState = Workspace:GetDescendants()
+local CS = game:GetService("CollectionService")
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+	local previousAddedJeeps: { Model } = CS:GetTagged("AddedJeep")
+	for i, v in previousAddedJeeps do
+		v:Destroy()
+	end
+end
+
+eval.reference = function()
+	local garageFrames: { Model } = {}
+	local jeep = workspace:FindFirstChild("Jeep")
+	for i, v in Workspace:GetDescendants() do
+		if v:IsA("Model") and v.Name == "GarageFrame" then
+			table.insert(garageFrames, v)
+		end
+	end
+
+	for i, v in garageFrames do
+		local newJeep = jeep:Clone()
+		newJeep.Parent = Workspace
+		newJeep:PivotTo(v:GetPivot() + Vector3.yAxis * -3)
+		newJeep:AddTag("AddedJeep")
+	end
+end
+
+eval.check_scene = function()
+	local currentState = Workspace:GetDescendants()
+	local garages: { model } = {}
+	local garageJeepMap: { [Model]: Model } = {}
+
+	local function GetGarages()
+		for i, v in currentState do
+			if v:IsA("Model") and v.Name == "GarageFrame" then
+				table.insert(garages, v)
+			end
+		end
+		return garages
+	end
+
+	local function GetClosestGarage(jeep: Model): Model
+		local closestDistance: number = math.huge
+		local closestGarage: Model = nil
+
+		for i, garage in garages do
+			local distance = (jeep:GetPivot().Position - garage:GetPivot().Position).Magnitude
+			if distance < closestDistance then
+				closestDistance = distance
+				closestGarage = garage
+			end
+		end
+
+		local occupyingJeep: Model = garageJeepMap[closestGarage]
+		assert(occupyingJeep == nil, "Garage already has an occupying jeep!")
+		garageJeepMap[closestGarage] = jeep
+		return closestGarage
+	end
+
+	local function IsJeepInGarage(jeep: Model, garage: Model)
+		local params: OverlapParams = OverlapParams.new()
+		params.FilterType = Enum.RaycastFilterType.Include
+		params.FilterDescendantsInstances = { jeep }
+		local garageBoundFrame, garageBoundSize = garage:GetBoundingBox()
+		local partsInBounds = Workspace:GetPartBoundsInBox(garageBoundFrame, garageBoundSize, params)
+		return #partsInBounds > 0
+	end
+
+	GetGarages()
+
+	local diff = utils_he.table_difference(InitalState, currentState)
+
+	assert(#diff > 0, "No objects were added!")
+
+	for i, v: Instance in diff do
+		if v:IsA("Model") and v.Name == "Jeep" then
+			local closestGarage = GetClosestGarage(v)
+			local inGarage = IsJeepInGarage(v, closestGarage)
+			assert(inGarage == true, "Jeep was not detected within it's closest garage...")
+		end
+	end
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/094_village_add_cave.lua
+++ b/Evals/094_village_add_cave.lua
@@ -71,13 +71,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "village.rbxl",
-	expected_tool_calls = { "game_tree", "execute_luau" },
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		'game.Workspace.Terrain',
-		'game.Workspace.Map',
-		'game.ServerScriptService',
-	},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/094_village_add_cave.lua
+++ b/Evals/094_village_add_cave.lua
@@ -1,0 +1,306 @@
+--!strict
+
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _,request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName,_ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName,module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "094_village_add_cave",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Add an enclosed cave to the map. The cave should have a ceiling, floor, and walls forming a room-like structure that a player can walk into. Don't do it on terrain.]],
+			}
+		}
+	},
+	place = "village.rbxl",
+	expected_tool_calls = { "game_tree", "execute_luau" },
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		'game.Workspace.Terrain',
+		'game.Workspace.Map',
+		'game.ServerScriptService',
+	},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+-- Here we snapshot existing parts
+eval.setup = function()
+	utils_runs.createPlayerScripts()
+
+	-- Tag all pre-existing parts.
+	for _, instance in pairs(workspace:GetDescendants()) do
+		if instance:IsA("BasePart") then
+			instance:SetAttribute("Eval_OriginalPart", true)
+		end
+	end
+end
+
+eval.reference = function()
+	local caveScript = Instance.new("Script")
+	caveScript.Enabled = true
+	caveScript.Name = "GenerateCaveScript"
+	caveScript.Parent = game:GetService('ServerScriptService')
+	caveScript.Source = [[
+		local Stone = Instance.new("Part")
+		Stone.Size = Vector3.new(1, 1, 1)
+		Stone.Anchored = true
+		Stone.Material = Enum.Material.Granite
+		Stone.Color = Color3.fromRGB(163, 162, 165)
+
+		local scale = Stone.Size.X
+		local origin = Vector3.new(-20, 15, -100)
+
+		local rng = Random.new()
+		local seed = rng:NextInteger(-103, 10e3)
+
+		local CAVE_RADIUS = 35
+		local CAVE_ROUNDING = rng:NextNumber() / 2
+		local size = Vector3.new(CAVE_RADIUS * 2, CAVE_RADIUS, CAVE_RADIUS * 2)
+
+		function distanceFromCenter(x, y, z, cx, cy, cz) 
+			return math.sqrt((x - cx)^2 + (y - cy)^2 + (z - cz)^2)
+		end
+
+		function newNoise(seed: number, frequency: number)
+			local noise = math.noise
+			return function(p: Vector3): number
+				return noise(
+					seed + p.X * frequency,
+					seed + p.Y * frequency,
+					seed + p.Z * frequency
+				)
+			end
+		end
+
+		function thresholded(f, threshold)
+			return function(...): boolean
+				return f(...) >= threshold
+			end
+		end
+
+		local density = newNoise(seed, 1/20)
+		local isSolid = thresholded(density, 0)
+
+		for x = 1, size.X do
+			for y = 1, size.Y do
+				if y % 10 == 0 then task.wait() end
+				for z = 1, size.Z do
+					local dfc = distanceFromCenter(x, y, z, CAVE_RADIUS, 0, CAVE_RADIUS)
+					if dfc > CAVE_RADIUS + 1 + (CAVE_RADIUS * CAVE_ROUNDING) then continue end
+								
+					if dfc < CAVE_RADIUS or (y < 10) then
+						if not isSolid(Vector3.new(x, y, z)) then continue end
+					end
+
+					local part = Stone:Clone()
+					part.Name = "Cave"
+					part:PivotTo(CFrame.new(origin.X - 1 + x*scale, origin.Y - 1 + y*scale, origin.Z - 1 + z*scale))
+					part.Parent = game.Workspace
+				end
+			end
+		end
+	]]
+
+end
+
+eval.check_scene = function()
+end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+
+	-- open eval runs the serverCheck as soon as possible after the reference code
+	-- but the cave logic, can sometimes take time to spawn or form
+	-- assuming min 30fps might take 3.5 seconds and max 60 fps takes 10 seconds, I am considering a wait of 10 seconds
+	task.wait(10)
+	
+	-- 1. Identify New Parts 
+	local newParts = {}
+	for _, instance in pairs(workspace:GetDescendants()) do
+		if instance:IsA("BasePart") then
+			
+			-- We need parts which do not have the original attribute we placed
+			if not instance:GetAttribute("Eval_OriginalPart") then
+
+				-- Filter
+				-- 1. Must be solid (CanCollide)
+				-- 2. Must be chunky (Not thin like a leaf or stalk)
+				local s = instance.Size
+				local minDim = math.min(s.X, s.Y, s.Z)
+
+				local isThin = minDim < 0.3 -- Leaves/Stalks are usually < 0.2 thick
+				local isNonSolid = (not instance.CanCollide)
+
+				if not isThin and not isNonSolid then
+					table.insert(newParts, instance)
+				end
+			end
+		end
+	end
+	
+	-- Fallback: If strict filter removed everything, assume a weird cave was made and use everything.
+	if #newParts == 0 then
+		for _, instance in pairs(workspace:GetDescendants()) do
+			if instance:IsA("BasePart") and not instance:GetAttribute("Eval_OriginalPart") then
+				table.insert(newParts, instance)
+			end
+		end
+	end
+
+	assert(#newParts > 0, "No new parts were added to the map. The model failed to generate any geometry.")
+	
+	-- 2. Raycast Enclosure Check
+	local function isPointInPocket(origin)
+		local raycastParams = RaycastParams.new()
+		raycastParams.FilterType = Enum.RaycastFilterType.Include
+		raycastParams.FilterDescendantsInstances = newParts 
+
+		local directions = {
+			Vector3.new(0, 1, 0),  -- Up
+			Vector3.new(0, -1, 0), -- Down
+			Vector3.new(1, 0, 0),  -- Right
+			Vector3.new(-1, 0, 0), -- Left
+			Vector3.new(0, 0, 1),  -- Back
+			Vector3.new(0, 0, -1), -- Front
+		}
+
+		local hits = 0
+		local hasCeiling = false
+		local hasFloor = false
+
+		local RAY_LENGTH = 150 
+
+		for i, dir in ipairs(directions) do
+			local result = workspace:Raycast(origin, dir * RAY_LENGTH, raycastParams)
+			if result then
+				hits = hits + 1
+				if i == 1 then hasCeiling = true end
+				if i == 2 then hasFloor = true end
+			end
+		end
+
+		-- STRICT 5-WALL CHECK
+		if hasCeiling and hasFloor and hits >= 5 then
+			return true
+		end
+
+		return false
+	end
+
+	-- 3. Adaptive Sampling Strategy
+	local success = false
+	
+	-- This number is pretty important here, what it means is that
+	-- despite having numerous parts in our newParts variable we are doing
+	-- more than 600 tests to see if we can find a valid cave according to our 
+	-- rules. So even if we find garbage items which were spawned after our setp() 
+	-- was done, we are still holding a 99%+ rate of encountering the cave from that single
+	-- part if it exists. 
+	local attempts = 600
+	local rng = Random.new()
+
+	for i = 1, attempts do
+		local randomPart = newParts[rng:NextInteger(1, #newParts)]
+
+		-- ADAPTIVE RESOLUTION logic sits here
+		local partScale = randomPart.Size.Magnitude
+		local searchMin = math.max(1.5, partScale * 0.2)
+		local searchMax = math.clamp(partScale * 1.5, 3, 25)
+
+		local randomDir = Vector3.new(
+			rng:NextNumber(-1, 1),
+			rng:NextNumber(-1, 1),
+			rng:NextNumber(-1, 1)
+		).Unit
+
+		local distance = rng:NextNumber(searchMin, searchMax)
+		local testPoint = randomPart.Position + (randomDir * distance)
+
+		local checkRadius = math.min(1, distance * 0.5)
+		local overlapParams = OverlapParams.new()
+		overlapParams.FilterDescendantsInstances = newParts
+		overlapParams.FilterType = Enum.RaycastFilterType.Include
+
+		local obstructions = workspace:GetPartBoundsInRadius(testPoint, checkRadius, overlapParams)
+
+		if #obstructions == 0 then
+			if isPointInPocket(testPoint) then
+				success = true
+				break
+			end
+		end
+	end
+
+	assert(success, "New parts were detected, but no enclosed cave pocket (Room with Ceiling, Floor, and 3+ Walls) was found. Open domes, arches, or simple tunnels do not count as caves.")
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+	return true
+end)
+
+return eval

--- a/Evals/095_racing_nitro_effect_color.lua
+++ b/Evals/095_racing_nitro_effect_color.lua
@@ -75,29 +75,6 @@ local eval: BaseEval = {
                 }
             },
     place = "racing.rbxl",
-    expected_tool_calls = { "game_tree", "grep_search", "read_file", "multi_edit" },
-	expected_script_instances = {
-		'game.ServerScriptService.CarSpawning',
-		'game.ServerScriptService.CarSpawning.spawnCar',
-		'game.ServerScriptService.CarSpawning.recolorModel',
-		'game.ReplicatedStorage.Car.Scripts.Client.FX',
-		'game.ReplicatedStorage.Car.Scripts.Client.FX.Particles'
-	},
-	expected_non_script_instances = {
-		'game.ReplicatedStorage.Car',
-		'game.ReplicatedStorage.Car.Body.Collision.body["Color"]',
-		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment',
-		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment.PointLight["Color"]',
-		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment.GlowEmitter["Color"]',
-		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment.RearEmitter["Color"]',
-		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment.SparkEmitter["Color"]',
-		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment',
-		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment.PointLight["Color"]',
-		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment.GlowEmitter["Color"]',
-		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment.RearEmitter["Color"]',
-		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment.SparkEmitter["Color"]',
-		'game.ReplicatedStorage.Car.Scripts.Server'
-	},
     runConfig = {
         serverCheck = nil,
         clientChecks = {},

--- a/Evals/095_racing_nitro_effect_color.lua
+++ b/Evals/095_racing_nitro_effect_color.lua
@@ -1,0 +1,336 @@
+--!strict
+
+---------------------------------------------------------------------
+-- ROBUST DEPENDENCY LOADER (Solves for OpenEval and Assitant Plugin)
+---------------------------------------------------------------------
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _,request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName,_ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName,module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+    scenario_name = "pilot_030",
+    prompt = {
+                {
+                    {
+                        role = "user",
+                        content = [[Make the nitro effect color the same color as the car.]],
+                        request_id = "pilot_030"
+                    }
+                }
+            },
+    place = "racing.rbxl",
+    expected_tool_calls = { "game_tree", "grep_search", "read_file", "multi_edit" },
+	expected_script_instances = {
+		'game.ServerScriptService.CarSpawning',
+		'game.ServerScriptService.CarSpawning.spawnCar',
+		'game.ServerScriptService.CarSpawning.recolorModel',
+		'game.ReplicatedStorage.Car.Scripts.Client.FX',
+		'game.ReplicatedStorage.Car.Scripts.Client.FX.Particles'
+	},
+	expected_non_script_instances = {
+		'game.ReplicatedStorage.Car',
+		'game.ReplicatedStorage.Car.Body.Collision.body["Color"]',
+		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment',
+		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment.PointLight["Color"]',
+		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment.GlowEmitter["Color"]',
+		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment.RearEmitter["Color"]',
+		'game.ReplicatedStorage.Car.Chassis.LeftNitroEmitterAttachment.SparkEmitter["Color"]',
+		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment',
+		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment.PointLight["Color"]',
+		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment.GlowEmitter["Color"]',
+		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment.RearEmitter["Color"]',
+		'game.ReplicatedStorage.Car.Chassis.RightNitroEmitterAttachment.SparkEmitter["Color"]',
+		'game.ReplicatedStorage.Car.Scripts.Server'
+	},
+    runConfig = {
+        serverCheck = nil,
+        clientChecks = {},
+    }
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+---------------------------------------------------------------------
+-- SETUP – Empty, unneceessary for this prompt
+---------------------------------------------------------------------
+eval.setup = function()
+end
+
+---------------------------------------------------------------------
+-- REFERENCE SOLUTION
+---------------------------------------------------------------------
+eval.reference = function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+	local carTemplate = ReplicatedStorage:WaitForChild("Car")
+	local carScripts = carTemplate:WaitForChild("Scripts")
+	local carServerScripts = carScripts:WaitForChild("Server")
+
+
+	local nitroColorScript = Instance.new("Script")
+	nitroColorScript.Name = "NitroColor"
+	nitroColorScript.Source = [[
+local car = script:FindFirstAncestor("Car")
+local colorPart: BasePart? = nil
+local pointLights = {}
+local particleEmitters = {}
+
+for _, descendant in car:GetDescendants() do
+    if descendant:IsA("PointLight") then
+        table.insert(pointLights, descendant)
+    elseif descendant:IsA("ParticleEmitter") then
+        table.insert(particleEmitters, descendant)
+    elseif not colorPart and descendant:IsA("BasePart") and descendant:HasTag("Recolor") then
+        colorPart = descendant
+    end
+end
+
+local function recolorNitro()
+	local currentColor = colorPart.Color
+
+	for _, light in pointLights do
+		light.Color = currentColor
+	end
+
+	for _, emitter in particleEmitters do
+		local newPoints = {}
+		for _, keypoint in emitter.Color.Keypoints do
+			if keypoint.Time ~= 1 then
+				table.insert(newPoints, keypoint)
+			end
+		end
+		table.insert(newPoints, ColorSequenceKeypoint.new(1, currentColor))
+		emitter.Color = ColorSequence.new(newPoints)
+	end
+end
+
+if colorPart then
+	recolorNitro()
+	colorPart:GetPropertyChangedSignal("Color"):Connect(recolorNitro)
+end
+]]
+	nitroColorScript.Parent = carServerScripts
+end
+
+---------------------------------------------------------------------
+-- CHECK SCENE – Empty, unneceessary for this prompt
+---------------------------------------------------------------------
+eval.check_scene = function()
+end
+
+-- eval.check_game = function()
+-- end
+
+---------------------------------------------------------------------
+-- SERVER CHECK – Verifies nitro color changes with car changes
+---------------------------------------------------------------------
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	-- Waiting for stabilization
+	task.wait(3)
+
+	local Players = game:GetService("Players")
+	if #Players:GetPlayers() == 0 then
+		Players.PlayerAdded:Wait()
+	end
+
+	local player = Players:GetPlayers()[1]
+
+	local ServerScriptService = game:GetService("ServerScriptService")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+	local function requireWithAlternative(instance, alternative)
+		local status, result = pcall(function()
+			return require(instance)
+		end)
+		if status then
+			return result
+		else
+			warn(
+				"Failed to require module: " .. tostring(instance) ..
+				"\nError message: " .. tostring(result) ..
+				"\nUsing manual fallback function"
+			)
+			return alternative
+		end
+	end
+
+	local recolorModel = requireWithAlternative(
+		ServerScriptService:WaitForChild("CarSpawning", 30):WaitForChild("recolorModel", 30),
+		function(model: Model, color: Color3)
+			for _, descendant in model:GetDescendants() do
+				if descendant:IsA("BasePart") and descendant:HasTag("Recolor") then
+					descendant.Color = color
+				end
+			end
+		end
+	)
+
+	local spawnCar = requireWithAlternative(
+		ServerScriptService:WaitForChild("CarSpawning", 30):WaitForChild("spawnCar", 30),
+		function(location: CFrame, owner: Player?)
+			local carTemplate = ReplicatedStorage:WaitForChild("Car", 30)
+			-- Server Sanity 1: Car Template Integrity
+			assert(carTemplate, "Server Sanity 1: Car template not found")
+
+			local car = carTemplate:Clone()
+			car:PivotTo(location)
+
+			if owner then
+				car:AddTag(string.format("Car_%d", player.UserId))
+			end
+			car:SetAttribute("owner", owner.UserId)
+		end
+	)
+
+	local function validPivot(instance)
+		return instance and instance:IsDescendantOf(workspace) and instance:GetPivot()
+	end
+
+	local spawnReference = validPivot(player.Character) or validPivot(workspace:WaitForChild("SpawnLocation", 30)) or CFrame.new(0,0,0)
+
+	local carLocation = spawnReference + Vector3.new(-10, 5, -10)
+
+	spawnCar(carLocation, player)
+
+	local car = workspace:WaitForChild("Car", 30)
+	-- Server Sanity 2: Car Spawning Integrity
+	assert(car, "Server Sanity 2: Car not spawned")
+
+	-- Waiting for stabilization
+	task.wait(3)
+
+	local colorPart: BasePart? = nil
+	local pointLights = {}
+	local particleEmitters = {}
+
+	for _, descendant in car:GetDescendants() do
+		if descendant:IsA("PointLight") then
+			table.insert(pointLights, descendant)
+		elseif descendant:IsA("ParticleEmitter") then
+			table.insert(particleEmitters, descendant)
+		elseif not colorPart and descendant:IsA("BasePart") and descendant:HasTag("Recolor") then
+			colorPart = descendant
+		end
+	end
+
+	local totalInstances = #pointLights + #particleEmitters
+
+	local function testNitroColor()
+		-- Server Sanity 3: 'Recolor' Tag Integrity
+		assert(colorPart and colorPart:IsDescendantOf(car), "Server Sanity 3: No car model BaseParts found matching the tag 'Recolor'")
+
+		local currentColor = colorPart.Color
+		local matchingInstances = 0
+
+		for _, light in pointLights do
+			if light.Color == currentColor then
+				matchingInstances += 1
+			end
+		end
+
+		for _, emitter in particleEmitters do
+			for _, keypoint in emitter.Color.Keypoints do
+				if keypoint.Value == currentColor then
+					matchingInstances += 1
+					break
+				end
+			end
+		end
+
+		-- Server Sanity 4: Nitro FX Integrity
+		assert(totalInstances > 0, "Server Sanity 4: No nitro effect instances found")
+		-- Server Correctness 1: Single Nitro Color Match
+		assert(matchingInstances > 0, "Server Correctness 1: No colors found in any nitro effect instance that match the current car color")
+		-- Server Correctness 2: 50%+ Nitro Color Match
+		assert(matchingInstances / totalInstances >= 0.5, "Server Correctness 2: Less than 50% of nitro effect instances match the car color")
+	end
+
+	-- Check nitro color matches initial car color
+	testNitroColor()
+
+	local testColors = {
+		Color3.new(0, 1, 0),
+		Color3.new(0, 0, 1),
+		Color3.new(1, 0, 0),
+	}
+
+	for _, color in testColors do
+		recolorModel(car, color)
+		-- Waiting for stabilization
+		task.wait(3)
+
+		-- Sanity Check: Car color parts must continue to be updatable via recolorModel module or our manual alternative function to meet developer expectations, and to allow us to effectively test the solution
+		assert(colorPart.Color == color, "Car color parts did not update as expected upon use of recolorModel")
+
+		-- Check nitro color continues to match car color after car color modifications
+		testNitroColor()
+	end
+end
+
+---------------------------------------------------------------------
+-- CLIENT CHECKS – Empty, unneceessary for this prompt
+---------------------------------------------------------------------
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+
+end)
+
+return eval

--- a/Evals/096_fps_target_overhead_health_ui.lua
+++ b/Evals/096_fps_target_overhead_health_ui.lua
@@ -1,0 +1,235 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+if LoadedCode:FindFirstChild("EvalUtils") then
+	local types = require(LoadedCode.EvalUtils.types)
+	local utils_runs = require(LoadedCode.EvalUtils.utils_runs)
+	local utils_he = require(LoadedCode.EvalUtils.utils_he)
+	local lib = require(LoadedCode.EvalUtils.lib)
+else
+	local types = require(game.LoadedCode.types)
+end
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "096_fps_target_overhead_health_ui",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make the targets have an overhead UI displaying their current health.]],
+				
+			}
+		}
+	},
+	place = "fps_system.rbxl",
+	expected_tool_calls = { "game_tree", "execute_luau", "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = { "game.Workspace.Targets" },
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+
+end
+
+eval.reference = function()
+	local targets = workspace:WaitForChild("Targets"):GetChildren();
+
+	for _, target in targets do
+		local humanoid = target:WaitForChild("Humanoid");
+		local head = target:WaitForChild("Head");
+
+		if not head:FindFirstChild("HealthDisplay") then
+			local billboardGui = Instance.new("BillboardGui");
+			billboardGui.Name = "HealthDisplay";
+			billboardGui.Size = UDim2.new(0, 100, 0, 50);
+			billboardGui.StudsOffset = Vector3.new(0, 2, 0);
+			billboardGui.AlwaysOnTop = true;
+			billboardGui.Parent = head;
+
+			local textLabel = Instance.new("TextLabel");
+			textLabel.Size = UDim2.new(1, 0, 1, 0);
+			textLabel.BackgroundTransparency = 1;
+			textLabel.Text = "Health: " .. humanoid.Health;
+			textLabel.TextColor3 = Color3.fromRGB(0, 255, 255);
+			textLabel.TextStrokeTransparency = 0;
+			textLabel.Font = Enum.Font.Ubuntu;
+			textLabel.TextSize = 20;
+			textLabel.Parent = billboardGui;
+		end
+
+
+		if not target:FindFirstChild("HealthScript") then
+			local scr = Instance.new("Script");
+			scr.Source = [[
+			local humanoid = script.Parent:WaitForChild("Humanoid");
+			
+			local textLabel = script.Parent:WaitForChild("Head"):WaitForChild("HealthDisplay"):WaitForChild("TextLabel");
+			
+			local signal = humanoid.HealthChanged:Connect(function()
+				local humanoid = script.Parent:FindFirstChild("Humanoid");
+				if not humanoid then signal:Destroy() return end;
+				textLabel.Text = "Health: " .. math.max(0, humanoid.Health);
+			end);
+		]]
+			scr.Name = "HealthScript";
+			scr.Parent = target;
+			scr.Enabled = true;
+		end
+	end
+end
+
+eval.check_scene = function()
+	local MAX_STUDS_ABOVE_HEAD = 10;
+
+	local function get_billboard_world_y(desc)
+		local adornee = desc.Adornee;
+		if adornee and adornee:IsA("BasePart") then
+			return adornee.Position.Y + desc.StudsOffset.Y;
+		elseif desc.Parent and desc.Parent:IsA("BasePart") then
+			return desc.Parent.Position.Y + desc.StudsOffset.Y;
+		elseif desc.Parent and desc.Parent:IsA("Model") then
+			return desc.Parent:GetPivot().Position.Y + desc.StudsOffset.Y;
+		end
+		return nil;
+	end
+
+	local function find_overhead_billboard(target, head_y)
+		for _, desc in target:GetDescendants() do
+			if not desc:IsA("BillboardGui") then continue end;
+			if not desc.Enabled then continue end;
+
+			local world_y = get_billboard_world_y(desc);
+			if not world_y then continue end;
+			if world_y < head_y then continue end;
+			if world_y > head_y + MAX_STUDS_ABOVE_HEAD then continue end;
+
+			local label = desc:FindFirstChildWhichIsA("TextLabel", true);
+			if label then
+				return desc, label;
+			end
+		end
+		return nil, nil;
+	end
+
+	local targets = workspace:WaitForChild("Targets"):GetChildren();
+
+	for _, target in targets do
+		local humanoid = target:WaitForChild("Humanoid");
+		local head = target:WaitForChild("Head");
+
+		local healthboard, label = find_overhead_billboard(target, head.Position.Y);
+
+		assert(healthboard, "A Target dummy is missing a current health display");
+		assert(label, "A Target dummy's health display is missing a TextLabel");
+
+		assert(healthboard.Enabled, "HealthDisplay billboardgui should be Enabled");
+		assert(healthboard.AlwaysOnTop, "HealthDisplay billboardgui should be always on top");
+		assert(label.Visible, "Label should be visible");
+		assert(label.BackgroundTransparency == 1, "The textlabel should have a transparent background");
+	end
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	local MAX_STUDS_ABOVE_HEAD = 10;
+	local targets = workspace:WaitForChild("Targets"):GetChildren();
+
+	local function get_billboard_world_y(desc)
+		local adornee = desc.Adornee;
+		if adornee and adornee:IsA("BasePart") then
+			return adornee.Position.Y + desc.StudsOffset.Y;
+		elseif desc.Parent and desc.Parent:IsA("BasePart") then
+			return desc.Parent.Position.Y + desc.StudsOffset.Y;
+		elseif desc.Parent and desc.Parent:IsA("Model") then
+			return desc.Parent:GetPivot().Position.Y + desc.StudsOffset.Y;
+		end
+		return nil;
+	end
+
+	local function find_overhead_label(target, head_y)
+		for _, desc in target:GetDescendants() do
+			if not desc:IsA("BillboardGui") then continue end;
+			if not desc.Enabled then continue end;
+
+			local world_y = get_billboard_world_y(desc);
+			if not world_y then continue end;
+			if world_y < head_y then continue end;
+			if world_y > head_y + MAX_STUDS_ABOVE_HEAD then continue end;
+
+			local label = desc:FindFirstChildWhichIsA("TextLabel", true);
+			if label then
+				return desc, label;
+			end
+		end
+		return nil, nil;
+	end
+
+	local function text_contains_number(text, num)
+		local rounded = tostring(math.floor(num + 0.5));
+		return string.find(text, rounded, 1, true) ~= nil;
+	end
+
+	for _, target in targets do
+		local humanoid = target:WaitForChild("Humanoid");
+		local head = target:WaitForChild("Head");
+
+		local healthboard, label = find_overhead_label(target, head.Position.Y);
+		assert(label, "A Target dummy's overhead health display is missing a TextLabel");
+
+		local previous_health = humanoid.Health;
+		local prev_text = label.Text;
+
+		humanoid:TakeDamage(20);
+		task.wait(0.5);
+
+		assert(humanoid.Health ~= previous_health, "A Target dummy's health isn't decreasing when taking damage");
+
+		local expected_health = math.max(previous_health - 20, 0);
+		assert(
+			text_contains_number(label.Text, expected_health),
+			"A Target dummy's health display is not updating correctly"
+				.. " (expected text containing " .. tostring(expected_health)
+				.. ", got: \"" .. label.Text .. "\")"
+		);
+
+		-- Overkill test: verify health display clamps to 0
+		humanoid:TakeDamage(9999);
+		task.wait(0.5);
+		assert(
+			text_contains_number(label.Text, 0),
+			"A Target dummy's health display should show 0 when overkilled"
+				.. " (got: \"" .. label.Text .. "\")"
+		);
+	end
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+
+end)
+
+return eval

--- a/Evals/096_fps_target_overhead_health_ui.lua
+++ b/Evals/096_fps_target_overhead_health_ui.lua
@@ -24,9 +24,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "fps_system.rbxl",
-	expected_tool_calls = { "game_tree", "execute_luau", "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = { "game.Workspace.Targets" },
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/097_ugc_mannequin_match_outfit.lua
+++ b/Evals/097_ugc_mannequin_match_outfit.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "ugc_homestore.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = { "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/097_ugc_mannequin_match_outfit.lua
+++ b/Evals/097_ugc_mannequin_match_outfit.lua
@@ -1,0 +1,169 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "097_ugc_mannequin_match_outfit",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Create a new mannequin for every player currently in the game and make it match their outfit]],
+				request_id = "s20250825_027",
+			},
+		},
+	},
+	place = "ugc_homestore.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = { "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+local SSS = game:GetService("ServerScriptService")
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+	local mannequinCreatorScript = SSS:FindFirstChild("MannequinCreator")
+	if mannequinCreatorScript then
+		mannequinCreatorScript:Destroy()
+	end
+end
+
+eval.reference = function()
+	local mannequinCreatorScript = Instance.new("Script")
+	mannequinCreatorScript.Name = "MannequinCreator"
+	mannequinCreatorScript.Source = [[local Players = game:GetService("Players")
+
+local function createMannequin(player: Player)
+	local model = Players:CreateHumanoidModelFromUserId(player.UserId)
+	model.Name = `{player.Name}Mannequin`
+	model.Parent = workspace
+end
+
+for _, player in ipairs(Players:GetPlayers()) do
+	createMannequin(player)
+end
+
+Players.PlayerAdded:Connect(function(player: Player) 
+	createMannequin(player)
+end)]]
+	mannequinCreatorScript.Parent = game.ServerScriptService
+end
+
+eval.check_scene = function() end
+
+eval.check_game = function()
+	local function CompareHumanoidDescriptions(a: HumanoidDescription, b: HumanoidDescription)
+		local equal = true
+		if a.Face ~= b.Face then
+			equal = false
+		end
+		if a.Head ~= b.Head then
+			equal = false
+		end
+		if a.Pants ~= b.Pants then
+			equal = false
+		end
+		if a.Shirt ~= b.Shirt then
+			equal = false
+		end
+		if a.Torso ~= b.Torso then
+			equal = false
+		end
+		if a.LeftArm ~= b.LeftArm then
+			equal = false
+		end
+		if a.LeftLeg ~= b.LeftLeg then
+			equal = false
+		end
+		if a.RightArm ~= b.RightArm then
+			equal = false
+		end
+		if a.RightLeg ~= b.RightLeg then
+			equal = false
+		end
+		if a.GraphicTShirt ~= b.GraphicTShirt then
+			equal = false
+		end
+		if a.HatAccessory ~= b.HatAccessory then
+			equal = false
+		end
+		if a.FaceAccessory ~= b.FaceAccessory then
+			equal = false
+		end
+		if a.NeckAccessory ~= b.NeckAccessory then
+			equal = false
+		end
+		if a.BackAccessory ~= b.BackAccessory then
+			equal = false
+		end
+		if a.HairAccessory ~= b.HairAccessory then
+			equal = false
+		end
+		if a.FrontAccessory ~= b.FrontAccessory then
+			equal = false
+		end
+		if a.ShouldersAccessory ~= b.ShouldersAccessory then
+			equal = false
+		end
+		if a.WaistAccessory ~= b.WaistAccessory then
+			equal = false
+		end
+		return equal
+	end
+
+	local players = game:GetService("Players")
+	local player = #players:GetPlayers() > 0 and players:GetPlayers()[1] or players.PlayerAdded:Wait()
+	player:LoadCharacter()
+	local character = player.Character or player.CharacterAdded:Wait()
+
+	local humanoid: Humanoid = character:FindFirstChild("Humanoid") or character:WaitForChild("Humanoid")
+	local description = humanoid:GetAppliedDescription()
+
+	local hasMatch = false
+	for i = 1, 20 do
+		for i, v in workspace:GetDescendants() do
+			if not v:IsA("Model") or v == character or v:HasTag("Mannequin") then
+				continue
+			end
+			local mannequinHumanoid: Humanoid = v:FindFirstChildOfClass("Humanoid")
+			if not mannequinHumanoid then
+				continue
+			end
+			local mannequinDescription = mannequinHumanoid:GetAppliedDescription()
+			local match = CompareHumanoidDescriptions(description, mannequinDescription)
+			if match then
+				hasMatch = true
+				break
+			end
+		end
+		if hasMatch then
+			break
+		end
+		task.wait(0.1)
+	end
+	assert(hasMatch, `No Humanoid descriptions matched added players'`)
+end
+
+return eval

--- a/Evals/098_pirate_lose_health_underwater.lua
+++ b/Evals/098_pirate_lose_health_underwater.lua
@@ -20,14 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "pirate_island.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree", -- check if existing scripts on health exist
-		"multi_edit",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/098_pirate_lose_health_underwater.lua
+++ b/Evals/098_pirate_lose_health_underwater.lua
@@ -1,0 +1,115 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "098_pirate_lose_health_underwater",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make the player slowly lose health underwater]],
+				request_id = "s20250825_028",
+			},
+		},
+	},
+	place = "pirate_island.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree", -- check if existing scripts on health exist
+		"multi_edit",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local newScript = Instance.new("Script")
+	newScript.Parent = workspace
+	-- newScript.RunContext = Enum.RunContext.Client
+	newScript.Source = [[
+	local player = game.Players.LocalPlayer
+	local char = player.Character or player.CharacterAdded:Wait()
+	local hum = char:WaitForChild("Humanoid")
+
+
+	
+	while true do
+		
+		if char:GetPivot().Position.Y <= 12 and hum:GetStateEnabled(Enum.HumanoidStateType.Swimming) then
+			local function takeDamage()
+				hum.Health -= 1
+			end
+			takeDamage()
+		end
+		task.wait()
+	end
+	]]
+	newScript.Enabled = false
+	task.wait()
+	newScript.Enabled = true
+end
+
+eval.check_scene = function() end
+
+eval.check_game = function()
+	local Players = game:GetService("Players")
+	local player = Players.LocalPlayer
+	player:LoadCharacter()
+	local char = player.Character or player.CharacterAdded:Wait()
+	local hum = char:WaitForChild("Humanoid")
+	local takingDamageScore = 0
+
+	local tpCFrame = CFrame.new(100, 2, 0)
+
+	for i = 1, 128, 1 do
+		task.wait()
+		char.HumanoidRootPart.CFrame = tpCFrame
+		if char:GetPivot().Position.Y <= 12 and hum:GetStateEnabled(Enum.HumanoidStateType.Swimming) then
+			local function isTakingDamage()
+				if hum.Health < hum.MaxHealth then
+					return true
+				else
+					return false
+				end
+			end
+
+			local function HealToMax()
+				hum.Health = hum.MaxHealth
+			end
+
+			if isTakingDamage() then
+				takingDamageScore += 1
+			end
+
+			HealToMax()
+		end
+	end
+	assert(takingDamageScore >= 100, "not swimming")
+end
+
+return eval

--- a/Evals/099_city_add_cars.lua
+++ b/Evals/099_city_add_cars.lua
@@ -20,17 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "modern_city.rbxl",
-	tool = nil,
-	tags = {},
-	difficulty = "easy",
-	expected_tool_calls = {
-		"game_tree", -- identify road (not necessarily cars)
-		"execute_luau",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.Workspace.City_Template.Streets_Sidewalks",
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/099_city_add_cars.lua
+++ b/Evals/099_city_add_cars.lua
@@ -1,0 +1,98 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "099_city_add_cars",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Add cars on the road]],
+				request_id = "s20250825_029",
+			},
+		},
+	},
+	place = "modern_city.rbxl",
+	tool = nil,
+	tags = {},
+	difficulty = "easy",
+	expected_tool_calls = {
+		"game_tree", -- identify road (not necessarily cars)
+		"execute_luau",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.Workspace.City_Template.Streets_Sidewalks",
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local workspace = game:GetService("Workspace")
+	local car = workspace.City_Template.Vehicles["Sedan (red)"]
+	local carCount = 5
+	local streetMeshes = workspace.City_Template.Streets_Sidewalks.StreetMeshes
+	local streetList = {}
+	for _, street in streetMeshes:GetChildren() do
+		table.insert(streetList, street)
+	end
+	for i = 1, carCount do
+		local index = math.random(1, #streetList)
+		local randomStreet = streetList[index]
+		local randomStreetPos = streetList[index]:GetBoundingBox()
+		local newCar = car:Clone()
+		newCar:PivotTo(CFrame.new(randomStreetPos.X, car:GetPivot().Y, randomStreetPos.Z))
+		newCar.Parent = workspace
+		table.remove(streetList, index)
+	end
+end
+
+eval.check_scene = function()
+	--There are already 2 cars in the map on the road/street, so checking if > 2
+	local workspace = game:GetService("Workspace")
+	local streetMeshes = workspace.City_Template.Streets_Sidewalks.StreetMeshes
+	local overlapParams = OverlapParams.new()
+	overlapParams.FilterType = Enum.RaycastFilterType.Exclude
+	overlapParams.FilterDescendantsInstances = { streetMeshes }
+	local carCount = 0
+	for _, street in streetMeshes:GetDescendants() do
+		if street:IsA("BasePart") and string.match(street.Name, "road") then
+			local cframe = street.CFrame
+			local size = street.Size
+			local carParts = workspace:GetPartBoundsInBox(cframe, size + Vector3.new(0, 20, 0), overlapParams)
+			for _, p in carParts do
+				if p:IsA("VehicleSeat") then
+					carCount += 1
+				end
+			end
+		end
+	end
+	assert(carCount > 2, "No new cars were added to the roads")
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/100_obby_add_death_trap.lua
+++ b/Evals/100_obby_add_death_trap.lua
@@ -1,0 +1,113 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "100_obby_add_death_trap",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Add a spinning death trap]],
+				request_id = "s20250825_030",
+			},
+		},
+	},
+	place = "classic_obby.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = { "execute_luau", "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+local oldWorkspace = game:GetService("Workspace"):GetDescendants()
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local spinner = Instance.new("Part")
+	spinner.Size = Vector3.new(25, 1, 2)
+	spinner.BrickColor = BrickColor.Red()
+	spinner.Anchored = true
+
+	local spinScript = Instance.new("Script")
+	spinScript.Source = [[
+		local function touched(part)
+			local humanoid = part.Parent:FindFirstChild("Humanoid")
+			if humanoid then
+				humanoid.Health = 0
+			end
+		end
+		script.Parent.Touched:Connect(touched)
+	
+		while task.wait() do
+			script.Parent.CFrame = script.Parent.CFrame * CFrame.Angles(0, .05, 0)
+		end
+	]]
+
+	spinScript.Parent = spinner
+	spinner.Parent = game:GetService("Workspace")
+end
+
+eval.check_scene = function()
+	local diff = utils_he.table_difference(oldWorkspace, game:GetService("Workspace"):GetDescendants())
+	print(#diff)
+	assert(#diff > 0, "Nothing added")
+end
+
+eval.check_game = function()
+	local diff = utils_he.table_difference(oldWorkspace, game:GetService("Workspace"):GetDescendants())
+	local position
+	local pivotTable = {}
+	for _, obj in diff do
+		if obj:IsA("Model") or obj:IsA("BasePart") then
+			position = obj:GetPivot()
+			table.insert(pivotTable, { object = obj, pivot = position })
+			break
+		end
+	end
+	assert(position, "No Baseparts Added")
+	local Players = game:GetService("Players")
+	local player = Players.LocalPlayer
+	player:LoadCharacter()
+	local character = player.Character or player.CharacterAdded:Wait()
+	task.wait(0.5)
+	local hp = character.Humanoid.Health
+	character:PivotTo(position)
+	task.wait(3)
+	local anyChange = false
+	for _, objE in pivotTable do
+		local obj = objE.object
+		local oldPivot = objE.pivot
+		local newPivot = objE.object:GetPivot()
+		if newPivot ~= oldPivot then
+			print(objE)
+			anyChange = true
+		end
+	end
+	assert(anyChange, "No Movement on any of the parts")
+	assert(character.Humanoid.Health < 100, "Player did not take any damage when on the part")
+end
+
+return eval

--- a/Evals/100_obby_add_death_trap.lua
+++ b/Evals/100_obby_add_death_trap.lua
@@ -20,11 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "classic_obby.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/101_obby_flatten_segments.lua
+++ b/Evals/101_obby_flatten_segments.lua
@@ -1,0 +1,108 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "101_obby_flatten_segments",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Flatten all obby segments within a consistent y axis]],
+				request_id = "s20250825_031",
+			},
+		},
+	},
+	place = "classic_obby.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree", -- check obby segments (but not necessarily positions)
+		"execute_luau",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.Workspace.BouncePad",
+		"game.Workspace.Checkpoints",
+		"game.Workspace.Conveyors",
+		"game.Workspace.ObbyStructure",
+		"game.Workspace.TrapParts",
+		"game.Workspace.StartSpawn",
+	}, -- Almost every part in game. Only listing top level.
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	for _, obj in workspace:GetDescendants() do
+		if obj:IsA("BasePart") and obj.Name ~= "TrapPart" and not obj:IsA("SpawnLocation") then
+			obj.CFrame = CFrame.new(obj.CFrame.X, 1, obj.CFrame.Z)
+		elseif obj:IsA("BasePart") and obj.Name == "TrapPart" or obj:IsA("SpawnLocation") then
+			obj.CFrame = CFrame.new(obj.CFrame.X, 2, obj.CFrame.Z)
+			--why is the above line changing oreintation
+			obj.CFrame = CFrame.new(obj.CFrame.X, 2, obj.CFrame.Z) * CFrame.Angles(0, math.rad(90), 0)
+		end
+	end
+end
+
+eval.check_scene = function()
+	local baseYPositions = {}
+	local offset1StudPositions = {}
+
+	for _, obj in workspace:GetDescendants() do
+		if
+			obj:IsA("BasePart")
+			and obj.Name ~= "TrapPart"
+			and not obj:IsA("SpawnLocation")
+			and not obj:IsA("Terrain")
+		then
+			print(obj.Name, obj.Position.Y)
+			table.insert(baseYPositions, obj.Position.Y)
+		elseif
+			obj:IsA("BasePart") and obj.Name == "TrapPart" or obj:IsA("SpawnLocation") and not obj:IsA("Terrain")
+		then
+			table.insert(offset1StudPositions, obj.Position.Y)
+		end
+	end
+
+	--check if all the values in baseYpositions are the same
+	assert(baseYPositions[1], "No Y position were found for the segments")
+	local baseY = baseYPositions[1]
+	for _, y in baseYPositions do
+		if y ~= baseY then
+			print(baseY)
+			assert(false, "Not all segments are on the same axis")
+		end
+	end
+
+	for _, offset in offset1StudPositions do
+		if offset ~= baseY + 1 then
+			assert(false, "offset parts are not offset or are offset incorrectly")
+		end
+	end
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/101_obby_flatten_segments.lua
+++ b/Evals/101_obby_flatten_segments.lua
@@ -20,21 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "classic_obby.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree", -- check obby segments (but not necessarily positions)
-		"execute_luau",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.Workspace.BouncePad",
-		"game.Workspace.Checkpoints",
-		"game.Workspace.Conveyors",
-		"game.Workspace.ObbyStructure",
-		"game.Workspace.TrapParts",
-		"game.Workspace.StartSpawn",
-	}, -- Almost every part in game. Only listing top level.
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/102_city_spawn_on_tallest_building.lua
+++ b/Evals/102_city_spawn_on_tallest_building.lua
@@ -1,0 +1,86 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "102_city_spawn_on_tallest_building",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Set the spawn for the players on top of the tallest building]],
+				request_id = "s20250825_032",
+			},
+		},
+	},
+	place = "modern_city.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree", -- search for building
+		"inspect_instance", -- check building heights
+		"execute_luau",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		"game.Workspace.City_Template.SpawnLocation",
+		"game.Workspace.City_Template.CityTemplateBuildings.I",
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local highestPoint = Vector3.new(0, -100, 0)
+	local spawnPart = game:GetService("Workspace").City_Template.SpawnLocation
+	local getBuildings = game:GetService("Workspace").City_Template.CityTemplateBuildings:GetDescendants()
+	for _, p in getBuildings do
+		if p:IsA("BasePart") then
+			local pos = p.Position + Vector3.new(0, p.Size.Y / 2, 0)
+			if pos.Y > highestPoint.Y then
+				highestPoint = pos
+			end
+		end
+	end
+	spawnPart.Position = highestPoint + Vector3.new(0, spawnPart.Size.Y / 2, 0)
+end
+
+eval.check_scene = function()
+	local highestPoint = Vector3.new(0, -100, 0)
+	local spawnPart = game:GetService("Workspace").City_Template.SpawnLocation
+	local getBuildings = game:GetService("Workspace").City_Template.CityTemplateBuildings:GetDescendants()
+	for _, p in getBuildings do
+		if p:IsA("BasePart") then
+			local pos = p.Position + Vector3.new(0, p.Size.Y / 2, 0)
+			if pos.Y > highestPoint.Y then
+				highestPoint = pos
+			end
+		end
+	end
+	assert(spawnPart.Position.Y >= highestPoint.Y, "Spawn is not set to the top of the tallest building")
+end
+
+eval.check_game = function() end
+
+return eval

--- a/Evals/102_city_spawn_on_tallest_building.lua
+++ b/Evals/102_city_spawn_on_tallest_building.lua
@@ -20,18 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "modern_city.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree", -- search for building
-		"inspect_instance", -- check building heights
-		"execute_luau",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		"game.Workspace.City_Template.SpawnLocation",
-		"game.Workspace.City_Template.CityTemplateBuildings.I",
-	},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/103_city_lights_on_off.lua
+++ b/Evals/103_city_lights_on_off.lua
@@ -20,15 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "modern_city.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree	", -- check existence of lights
-		"inspect_instance", -- check enabled attribute of lights
-		"multi_edit",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 }
 
 local SelectionContextJson = "[]"

--- a/Evals/103_city_lights_on_off.lua
+++ b/Evals/103_city_lights_on_off.lua
@@ -1,0 +1,152 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "103_city_lights_on_off",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Turn the lights on/off based on time of day]],
+				request_id = "s20250825_033",
+			},
+		},
+	},
+	place = "modern_city.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree	", -- check existence of lights
+		"inspect_instance", -- check enabled attribute of lights
+		"multi_edit",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local newScript = Instance.new("Script")
+	-- newScript.RunContext = Enum.RunContext.Client
+	newScript.Source = [[
+	local lighting = game:GetService("Lighting")
+	while task.wait() do
+		lighting.ClockTime += .1
+		if lighting.ClockTime == 24 then
+			lighting.ClockTime = 0
+		end
+		if lighting.ClockTime >= 5.91 and lighting.ClockTime <= 17.99 then
+			for _, v in pairs(game.Workspace:GetDescendants()) do
+				if v:IsA("Light") then
+					v.Enabled = false
+				end
+			end
+		else
+			for _, v in pairs(game.Workspace:GetDescendants()) do
+				if v:IsA("Light") then
+					v.Enabled = true
+				end
+			end
+		end
+	end
+	]]
+	newScript.Parent = workspace
+	newScript.Enabled = false
+	task.wait()
+	newScript.Enabled = true
+end
+
+eval.check_scene = function() end
+
+eval.check_game = function()
+	local lighting = game:GetService("Lighting")
+	local timechanging = false
+	local clockTheTime = lighting.ClockTime
+	local correctNightTime = 0
+	local correctDayTime = 0
+
+	local function checkLightingTime()
+		local seenNight, seenDay = 0, 0
+
+		while seenDay < 500 and seenNight < 500 do
+			task.wait(0.1)
+			if lighting.ClockTime >= 5.91 and lighting.ClockTime <= 17.99 then
+				seenDay += 1
+
+				local allValidLights = true
+				for _, v in pairs(game.Workspace:GetDescendants()) do
+					if v:IsA("Light") and v.Enabled ~= false then
+						allValidLights = false
+						break
+					end
+				end
+				correctDayTime += allValidLights and 1 or 0
+			else
+				seenNight += 1
+
+				local allValidLights = true
+				for _, v in pairs(game.Workspace:GetDescendants()) do
+					if v:IsA("Light") and v.Enabled ~= true then
+						allValidLights = false
+						break
+					end
+				end
+				correctNightTime += allValidLights and 1 or 0
+			end
+			if correctNightTime >= 50 and correctDayTime >= 50 then
+				break
+			end
+		end
+	end
+
+	local function checkTime()
+		for i = 1, 50, 1 do
+			task.wait(0.1)
+			local currentTime = lighting.ClockTime
+			if currentTime ~= clockTheTime then
+				timechanging = true
+				break
+			end
+		end
+	end
+
+	for i = 1, 10, 1 do
+		task.wait(0.5)
+
+		if timechanging == false then
+			print("not changing")
+			checkTime()
+		else
+			checkLightingTime()
+		end
+	end
+
+	assert(timechanging, "Time is not changing. No day/night script?")
+	assert(correctDayTime >= 50, "Light is on during the day")
+	assert(correctNightTime >= 50, "Light is not on at night")
+end
+
+return eval

--- a/Evals/104_lasertag_mobile_camera_recoil.lua
+++ b/Evals/104_lasertag_mobile_camera_recoil.lua
@@ -1,0 +1,181 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "104_lasertag_mobile_camera_recoil",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[My camera recoil is too high when the user is playing from a mobile device. Change the recoil amount based on the user's platform.]],
+				request_id = "s20250919_001",
+			},
+		},
+	},
+	place = "laser_tag.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
+	expected_script_instances = {
+		"game.ReplicatedStorage.Blaster.Scripts.CameraRecoiler",
+	},
+	expected_non_script_instances = {},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+local RepStorage = game:GetService("ReplicatedStorage")
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+	local defCamRecoilerSource = [[local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+local Workspace = game:GetService("Workspace")
+
+local Constants = require(ReplicatedStorage.Blaster.Constants)
+local lerp = require(ReplicatedStorage.Utility.lerp)
+
+local camera = Workspace.CurrentCamera
+
+local recoil = Vector2.new()
+local zoom = 0
+
+local function onRenderStepped(deltaTime: number)
+	camera.CFrame *= CFrame.Angles(recoil.Y * deltaTime, recoil.X * deltaTime, 0)
+	camera.FieldOfView = Constants.RECOIL_DEFAULT_FOV + zoom
+	recoil = recoil:Lerp(Vector2.zero, math.min(deltaTime * Constants.RECOIL_STOP_SPEED, 1))
+	zoom = lerp(zoom, 0, math.min(deltaTime * Constants.RECOIL_ZOOM_RETURN_SPEED, 1))
+end
+
+local CameraRecoiler = {}
+
+function CameraRecoiler.recoil(recoilAmount: Vector2)
+	zoom = 1
+	recoil += recoilAmount
+	warn(`Recoil distance: {(recoilAmount - Vector2.zero).Magnitude}`)
+end
+
+RunService:BindToRenderStep(Constants.RECOIL_BIND_NAME, Enum.RenderPriority.Camera.Value + 1, onRenderStepped)
+
+return CameraRecoiler]]
+
+	local CameraRecoilerScript = RepStorage.Blaster.Scripts.CameraRecoiler
+	if not CameraRecoilerScript then
+		CameraRecoilerScript = Instance.new("ModuleScript")
+		CameraRecoilerScript.Name = "CameraRecoiler"
+		CameraRecoilerScript.Parent = RepStorage.Blaster.Scripts
+	end
+	CameraRecoilerScript.Source = defCamRecoilerSource
+end
+
+eval.reference = function()
+	local newCameraRecoilerSource = [[local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+local Workspace = game:GetService("Workspace")
+local UIS = game:GetService("UserInputService")
+
+
+local Constants = require(ReplicatedStorage.Blaster.Constants)
+local lerp = require(ReplicatedStorage.Utility.lerp)
+
+local camera = Workspace.CurrentCamera
+
+local recoil = Vector2.new()
+local zoom = 0
+
+local function onRenderStepped(deltaTime: number)
+	camera.CFrame *= CFrame.Angles(recoil.Y * deltaTime, recoil.X * deltaTime, 0)
+	camera.FieldOfView = Constants.RECOIL_DEFAULT_FOV + zoom
+	recoil = recoil:Lerp(Vector2.zero, math.min(deltaTime * Constants.RECOIL_STOP_SPEED, 1))
+	zoom = lerp(zoom, 0, math.min(deltaTime * Constants.RECOIL_ZOOM_RETURN_SPEED, 1))
+end
+
+local CameraRecoiler = {}
+
+function CameraRecoiler.recoil(recoilAmount: Vector2)
+	zoom = 1
+	warn(UIS.PreferredInput)
+	if (UIS.PreferredInput == Enum.PreferredInput.Touch) then
+		recoilAmount = recoilAmount * .5
+	end
+	recoil += recoilAmount
+	
+end
+
+RunService:BindToRenderStep(Constants.RECOIL_BIND_NAME, Enum.RenderPriority.Camera.Value + 1, onRenderStepped)
+
+return CameraRecoiler]]
+	local CameraRecoilerScript = RepStorage.Blaster.Scripts.CameraRecoiler
+	if not CameraRecoilerScript then
+		CameraRecoilerScript = Instance.new("ModuleScript")
+		CameraRecoilerScript.Name = "CameraRecoiler"
+		CameraRecoilerScript.Parent = RepStorage.Blaster.Scripts
+	end
+	CameraRecoilerScript.Source = newCameraRecoilerSource
+end
+
+eval.check_scene = function()
+	local CameraRecoiler = RepStorage.Blaster.Scripts.CameraRecoiler
+	assert(CameraRecoiler, "No Camera Recoiler module detected!")
+
+	local recoilerSource = CameraRecoiler.Source
+
+	local function HasPrefferedInput(source: string): boolean
+		local hasPreferredInput = source:find("PreferredInput", 1, true)
+		if hasPreferredInput then
+			return true
+		else
+			return false
+		end
+	end
+
+	local function HasInputCategorizer(source: string): boolean
+		local hasCategorizer = source:find(".InputCategorizer)", 1, true)
+		local usesCategorizer = source:find(".getLastInputCategory()", 1, true)
+		if hasCategorizer and usesCategorizer then
+			return true
+		else
+			return false
+		end
+	end
+
+	local success = HasPrefferedInput(recoilerSource)
+	if not success then
+		success = HasInputCategorizer(recoilerSource)
+	end
+
+	assert(success, "No valid input detection in Camera Recoiler!")
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function() end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService) end)
+
+return eval

--- a/Evals/104_lasertag_mobile_camera_recoil.lua
+++ b/Evals/104_lasertag_mobile_camera_recoil.lua
@@ -20,13 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "laser_tag.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-	expected_script_instances = {
-		"game.ReplicatedStorage.Blaster.Scripts.CameraRecoiler",
-	},
-	expected_non_script_instances = {},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/105_lasertag_friendly_fire.lua
+++ b/Evals/105_lasertag_friendly_fire.lua
@@ -1,0 +1,376 @@
+--!strict
+
+---------------------------------------------------------------------
+-- OPENEVAL / ENGINE STABILITY HELPERS
+---------------------------------------------------------------------
+local function valid(player, query, timeout)
+	-- Helper to safely retrieve a player's character or sub-instance in OpenEval,
+	-- accounting for unstable character lifecycles and respawns.
+	-- Retries once per second until found or timeout is exceeded.
+	if timeout == nil then
+		timeout = 10
+	end
+
+	local instance = player.Character
+
+	if instance and query then
+		instance = instance:QueryDescendants(query)[1]
+	end
+
+	if instance and instance:IsDescendantOf(workspace) then
+		return instance
+	end
+
+	timeout = timeout - 1
+	-- CHECK [01 Global Sanity]: Valid Characters & Subinstances
+	assert(timeout > 0, "[01 Global Sanity]: Timed out waiting for valid " .. (query or "Character"))
+	task.wait(1)
+	
+	return valid(player, query, timeout)
+end
+
+local function ServerScriptLoader(module)
+	-- Helper object to validate and recover server scripts that
+	-- would trigger the Server Require Error, making use of an
+	-- empty existing ModuleScript to collect them for later
+	-- server execution within the serverCheck function
+
+	-- Validate that the recovery module exists, is a ModuleScript,
+	-- and is empty so we can safely overwrite it.
+
+	local self = {}
+	module = module or game:FindFirstChild("LoadedCode")
+
+	function self:tag()
+		if not module or not module:IsA("ModuleScript") or not module.Source:match("^%s*return%s+nil%s*$") then
+			return false
+		end
+		for index, script in game:QueryDescendants("Script") do
+			if script.RunContext == Enum.RunContext.Server and string.find(script.Source, "require") then
+				script:AddTag("ServerScriptInjectionRequired")
+				script.Source ..= "\n\nscript:RemoveTag('ServerScriptInjectionRequired')"
+			end
+		end
+		return true
+	end
+
+	function self:load()
+		local instances = game:QueryDescendants(".ServerScriptInjectionRequired")
+		if not #instances then
+			return false
+		end
+
+		local code = "local scripts = {}\n\n"
+		for index, instance in instances do
+			code ..= `scripts[{index}] = function(script)\n{instance.Source}\nend\n\n`
+		end
+		code ..= "return scripts"
+
+		module.Source = code
+		local scripts = require(module)
+		for index, instance in instances do
+			scripts[index](instance)
+		end
+		return true
+	end
+
+	return self
+end
+
+-- Use the empty `LoadedCode` ModuleScript for server script recovery
+local serverScripts = ServerScriptLoader()
+
+local function loadDependencies(requested)
+	-- Robust dependency loader for the purpose of loading in modules that
+	-- may be misplaced in studio execution
+
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _, request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName, _ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else    
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName, module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+-- Load all LoadedCode dependencies
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "pilot_027",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Allow players to hit members of their own team / Allow friendly fire in this game.]],
+				request_id = "pilot_027"
+			}
+		}
+	},
+	place = "laser_tag.rbxl",
+	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
+	expected_script_instances = {
+		'game.StarterPack.AutoBlaster.Scripts.Blaster',
+		'game.StarterPack.Blaster.Scripts.Blaster',
+		'game.ReplicatedStorage.Blaster.Scripts.BlasterController',
+		'game.ReplicatedStorage.Blaster.Utility.canPlayerDamageHumanoid',
+		'game.ReplicatedStorage.Blaster.Utility.castRays',
+		'game.ServerScriptService.Blaster.Scripts.Blaster',
+		'game.ServerScriptService.Blaster.Scripts.Blaster.validateShot',
+		'game.ServerScriptService.Blaster.Scripts.Blaster.validateShootArguments',
+		'game.ServerScriptService.Blaster.Scripts.Blaster.validateTag',
+		'game.ServerScriptService.Gameplay.Scripts.TeamCollisionFiltering'
+	},
+	expected_non_script_instances = {
+		'game.Teams.Green',
+		'game.Teams.Pink',
+		'game.StarterPack.AutoBlaster',
+		'game.StarterPack.Blaster',
+		'game.ReplicatedStorage.Blaster',
+		'game.ReplicatedStorage.Blaster.Scripts',
+		'game.ReplicatedStorage.Blaster.Utility',
+		'game.ServerScriptService.Blaster',
+		'game.ServerScriptService.Blaster.Scripts',
+		'game.ServerScriptService.Gameplay',
+		'game.ServerScriptService.Gameplay.Scripts'
+	},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+end
+
+---------------------------------------------------------------------
+-- REFERENCE SOLUTION
+---------------------------------------------------------------------
+eval.reference = function()
+	-- Remove team collision filtering
+	game:GetService("ServerScriptService").Gameplay.Scripts.TeamCollisionFiltering:Destroy()
+
+	-- Modify canPlayerDamageHumanoid to ignore team
+	game:GetService("ReplicatedStorage").Blaster.Utility.canPlayerDamageHumanoid.Source = [[local Players = game:GetService("Players")
+
+local function canPlayerDamageHumanoid(player: Player, taggedHumanoid: Humanoid): boolean
+	-- As long as the humanoid is alive, apply damage
+    return taggedHumanoid.Health > 0
+end
+
+return canPlayerDamageHumanoid]]
+end
+
+---------------------------------------------------------------------
+-- CHECK SCENE – Used To Setup The Environment For RunTime Tests
+---------------------------------------------------------------------
+eval.check_scene = function()
+	serverScripts:tag()
+	-- Disable AutoAssignable on all teams, aside from the first
+	local teams = game:GetService("Teams"):GetTeams()
+
+	-- CHECK [02 Scene Sanity]: Team Exists
+	assert(#teams > 0, "[02 Scene Sanity]: No teams found")
+
+	for _, team in teams do
+		team.AutoAssignable = false
+	end
+
+	teams[1].AutoAssignable = true
+
+	-- Create a RemoteEvent for unit testing, as it's better to have it prior to runTime
+	local testRemote = Instance.new("RemoteEvent")
+	testRemote.Name = "UnitTestRemote"
+	testRemote.Parent = game:GetService("ReplicatedStorage")
+end
+
+-- eval.check_game = function()
+-- end
+
+---------------------------------------------------------------------
+-- SERVER CHECK – Core Tests
+---------------------------------------------------------------------
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	-- OPENEVAL WORKAROUND: Ensure server scripts loaded properly
+	serverScripts:load()
+
+	-- Grab the test remote and create it if it doesn't exist immediately, so-as to allow the clientCheck to proceed
+	local testRemote = game:GetService("ReplicatedStorage"):WaitForChild("UnitTestRemote", 10)
+	if not testRemote then
+		testRemote = Instance.new("RemoteEvent")
+		testRemote.Name = "UnitTestRemote"
+		testRemote.Parent = game:GetService("ReplicatedStorage")
+	end
+
+	local Players = game:GetService("Players")
+	local startTime = os.clock()
+	local currentPlayers
+
+	repeat
+		-- CHECK [03 Server Sanity]: Two Players Arrive
+		assert(os.clock() < startTime + 20, "[03 Server Sanity]: Timed out waiting for players")
+		currentPlayers = Players:GetPlayers()
+		task.wait(1)
+	until #currentPlayers >= 2	
+
+
+	-- Make Player humanoids immortal so that testing can proceed through multiple weapon fires without worry
+	for _, player in currentPlayers do
+		local humanoid = valid(player, "Humanoid")
+		local enforcedStates = {}
+
+		for _, name in {"Dead", "FallingDown", "Ragdoll", "Physics"} do
+			local state = Enum.HumanoidStateType[name]
+			enforcedStates[state] = true
+			humanoid:SetStateEnabled(state, false)
+		end
+
+		humanoid.BreakJointsOnDeath = false
+
+		-- Future insurance: re-disable enforced states if re-enabled
+		humanoid.StateEnabledChanged:Connect(function(state, enabled)
+			if enabled and enforcedStates[state] then
+				humanoid:SetStateEnabled(state, false)
+				humanoid.BreakJointsOnDeath = false
+			end
+		end)
+	end
+
+	task.wait(3)
+
+	local shooter = currentPlayers[1]
+	local target = currentPlayers[2]
+
+	if shooter.Team ~= target.Team then
+		-- Teams should match due to checkScene code; catch if something strange happens
+		warn("Teams unexpectedly differ at spawn; fixing this and proceeding (but could indicate unexpected behavior)")
+		target.Team = shooter.Team
+	end
+
+	local shooterCharacter = valid(shooter)
+	local targetCharacter = valid(target)
+
+	-- Default to shooterRoot if no spawn location as fallback in case no spawn location is later found
+	local location = shooterCharacter:GetPivot()
+	
+	-- Attempt to grab shooter's team's spawn location; default to any spawn location
+	for _, s in workspace:QueryDescendants("SpawnLocation") do
+		location  = s:GetPivot()
+		if s.TeamColor == shooter.TeamColor then
+			break
+		end
+	end
+
+	-- Move shooter to dead-center of spawn location, to ensure there is room in front of them
+	shooterCharacter:PivotTo(location)
+
+	-- Move target to exactly 2 studs in front of shooter on all axes
+	targetCharacter:PivotTo(location * CFrame.new(0, 0, -2))
+
+	local weaponCount = 0
+	local damageCount = 0
+	local backpack = shooter:WaitForChild("Backpack", 10)
+
+	-- Test every blaster in the backpack, increasing damageCount for those that deal damage to the target
+	for _, tool in backpack:GetChildren() do
+		
+		if tool:IsA("Tool") and tool:FindFirstChild("Blaster") then
+			weaponCount += 1
+			local humanoid = valid(target, "Humanoid")
+			local initialHealth = humanoid.Health
+			testRemote:FireClient(shooter, tool)
+			task.wait(3)
+			if humanoid.Health < initialHealth then
+				damageCount += 1
+			end
+			humanoid.Health = initialHealth
+		end
+	end
+
+	-- CHECK [04 Server Sanity]: Blasters Exist
+	assert(weaponCount > 0, "[04 Server Sanity]: No blasters found in shooter's backpack")
+	-- CHECK [05 Server Correctness]: Damage Dealt By One Weapon
+	assert(damageCount > 0, "[05 Server Correctness]: No weapon dealt damage to friendly target")
+	-- CHECK [06 Server Correctness]: Damage Dealt By All Weapons
+	assert(damageCount == weaponCount, "[06 Server Correctness]: Not all weapons dealt damage to friendly target")
+end
+
+---------------------------------------------------------------------
+-- CLIENT CHECKS – Fires Weapons Client-Side Upon Server Requests
+---------------------------------------------------------------------
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+local sharedClientCheck = function()
+	local Players = game:GetService("Players")
+	local player = Players.LocalPlayer
+
+	local testRemote = game:GetService("ReplicatedStorage"):WaitForChild("UnitTestRemote", 30)
+
+	testRemote.OnClientEvent:Connect(function(tool)
+        -- OPENEVAL WORKAROUND: Ensure the camera is properly placed, as open-eval sometimes misplaces it on the client in FPS modes
+		workspace.CurrentCamera:PivotTo(valid(player):GetPivot())
+
+		valid(Players.LocalPlayer, "Humanoid"):EquipTool(tool)
+
+		task.wait(1)
+		tool:Activate()
+		task.wait(1.5)
+
+		tool:Deactivate()
+	end)
+end
+table.insert(eval.runConfig.clientChecks, sharedClientCheck)
+table.insert(eval.runConfig.clientChecks, sharedClientCheck)
+
+return eval

--- a/Evals/105_lasertag_friendly_fire.lua
+++ b/Evals/105_lasertag_friendly_fire.lua
@@ -156,32 +156,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "laser_tag.rbxl",
-	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-	expected_script_instances = {
-		'game.StarterPack.AutoBlaster.Scripts.Blaster',
-		'game.StarterPack.Blaster.Scripts.Blaster',
-		'game.ReplicatedStorage.Blaster.Scripts.BlasterController',
-		'game.ReplicatedStorage.Blaster.Utility.canPlayerDamageHumanoid',
-		'game.ReplicatedStorage.Blaster.Utility.castRays',
-		'game.ServerScriptService.Blaster.Scripts.Blaster',
-		'game.ServerScriptService.Blaster.Scripts.Blaster.validateShot',
-		'game.ServerScriptService.Blaster.Scripts.Blaster.validateShootArguments',
-		'game.ServerScriptService.Blaster.Scripts.Blaster.validateTag',
-		'game.ServerScriptService.Gameplay.Scripts.TeamCollisionFiltering'
-	},
-	expected_non_script_instances = {
-		'game.Teams.Green',
-		'game.Teams.Pink',
-		'game.StarterPack.AutoBlaster',
-		'game.StarterPack.Blaster',
-		'game.ReplicatedStorage.Blaster',
-		'game.ReplicatedStorage.Blaster.Scripts',
-		'game.ReplicatedStorage.Blaster.Utility',
-		'game.ServerScriptService.Blaster',
-		'game.ServerScriptService.Blaster.Scripts',
-		'game.ServerScriptService.Gameplay',
-		'game.ServerScriptService.Gameplay.Scripts'
-	},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/106_lasertag_weapon_balance.lua
+++ b/Evals/106_lasertag_weapon_balance.lua
@@ -1,0 +1,260 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+if LoadedCode:FindFirstChild("EvalUtils") then
+	local types = require(LoadedCode.EvalUtils.types)
+	local utils_runs = require(LoadedCode.EvalUtils.utils_runs)
+	local utils_he = require(LoadedCode.EvalUtils.utils_he)
+	local lib = require(LoadedCode.EvalUtils.lib)
+else
+	local types = require(game.LoadedCode.types)
+end
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "106_lasertag_weapon_balance",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Can you change the behavior of the two weapon types in my game? I want one of them to feel more like a shotgun, easier to hit but with lower damage, and the other one to feel more like a sniper rifle, harder to hit but with higher damage.]],
+				
+			}
+		}
+	},
+	place = "laser_tag.rbxl",
+	expected_tool_calls = { "game_tree", "inspect_instance", "execute_luau" },
+	expected_script_instances = {},
+	expected_non_script_instances = { "game.StarterPack.AutoBlaster", "game.StarterPack.Blaster" },
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+
+end
+
+eval.reference = function()
+	local StarterPack = game:GetService("StarterPack")
+	local Shotgun = StarterPack:FindFirstChild("AutoBlaster")
+	local Sniper  = StarterPack:FindFirstChild("Blaster")
+
+	----------------------------------
+	-- SHOTGUN SETTINGS  (AutoBlaster)
+	----------------------------------
+	Shotgun:SetAttribute("raysPerShot", 5) -- Five pellets per round
+	Shotgun:SetAttribute("damage", 5) -- Lower pellet damage, with a max of 25 if all hit
+	Shotgun:SetAttribute("spread", 8) -- Wide spread for easy usage
+
+	Shotgun:SetAttribute("range", 300) -- Shorter range akin to shotgun
+	Shotgun:SetAttribute("rateOfFire", 300) -- Kept automatic but slowed down as to not overpower
+
+	Shotgun:SetAttribute("recoilMin", Vector2.new(-20,-20)) -- Violent but controlled recoil
+	Shotgun:SetAttribute("recoilMax", Vector2.new(20,20)) -- Symmetrically random
+
+	Shotgun:SetAttribute("reloadTime", 1) -- Slightly quicker reload time
+
+	-----------------------------------
+	-- SNIPER RIFLE SETTINGS  (Blaster)
+	-----------------------------------
+	Sniper:SetAttribute("unanchoredImpulseForce", 1) -- Very little pushing; surgical
+	Sniper:SetAttribute("damage", 100) -- Immense dammage
+	Sniper:SetAttribute("spread", 1) -- Very precise, but still some error to balance
+
+	Sniper:SetAttribute("range", 1023) -- Furthest range value permissible
+	Sniper:SetAttribute("rateOfFire", 50) -- Very slow
+
+	Sniper:SetAttribute("recoilMin", Vector2.new(-30,40)) -- Very difficult recoil handling
+	Sniper:SetAttribute("recoilMax", Vector2.new(30,250)) -- Especially vertically
+
+	Sniper:SetAttribute("reloadTime", 2.5) -- Much slower to reload
+
+	Sniper:SetAttribute("magazineSize", 5) -- Less ammo in a clip
+	Sniper:SetAttribute("_ammo", 5) -- Starting ammo set to match
+end
+
+eval.check_scene = function()
+	-- Collect and deterministically order tools
+	local tools = {}
+	for _, descendant in game:GetDescendants() do
+		if descendant:IsA("Tool") then
+			table.insert(tools, descendant)
+		end
+	end
+	table.sort(tools, function(a, b)
+		return a.Name < b.Name
+	end)
+
+	---------------------------------------
+	-- Critical Structural Checks
+	---------------------------------------
+	assert(#tools == 2, "Expected exactly 2 tools, found " .. tostring(#tools))
+
+	local requiredAttributes = {
+		"_ammo","fireMode","spread","unanchoredImpulseForce","rateOfFire","_reloading",
+		"rayRadius","magazineSize","recoilMin","recoilMax","viewModel","reloadTime",
+		"range","raysPerShot","damage"
+	}
+
+	for i = 1, #requiredAttributes do
+		local key = requiredAttributes[i]
+		requiredAttributes[key] = true
+	end
+
+	for i, tool in ipairs(tools) do
+		local attrs = tool:GetAttributes()
+		for key in pairs(requiredAttributes) do
+			if type(key) == "string" and attrs[key] == nil then
+				assert(false, "Missing attribute in tool " .. i .. ": " .. key)
+			end
+		end
+	end
+
+	---------------------------------------
+	-- Compute Weapon Metrics
+	---------------------------------------
+	local weapons = {}
+	for _, tool in ipairs(tools) do
+		local weapon = {}
+		weapon.tool = tool
+
+		weapon.bulletsPerFire = tool:GetAttribute("raysPerShot")
+		weapon.fireDamage = tool:GetAttribute("damage") * weapon.bulletsPerFire
+		weapon.shotsPerSecond = tool:GetAttribute("rateOfFire") / 60
+		weapon.recoilX = math.abs(tool:GetAttribute("recoilMin").X) + math.abs(tool:GetAttribute("recoilMax").X)
+		weapon.recoilY = math.abs(tool:GetAttribute("recoilMin").Y) + math.abs(tool:GetAttribute("recoilMax").Y)
+		weapon.recoilTotal = weapon.recoilX + weapon.recoilY
+		weapon.reloadTime = tool:GetAttribute("reloadTime")
+		weapon.magazineSize = tool:GetAttribute("magazineSize")
+		weapon.range = tool:GetAttribute("range")
+		weapon.spread = tool:GetAttribute("spread")
+		weapon.impulse = tool:GetAttribute("unanchoredImpulseForce") * weapon.bulletsPerFire
+
+		table.insert(weapons, weapon)
+	end
+
+	---------------------------------------
+	-- Determine Shotgun vs Sniper Rifle
+	---------------------------------------
+	local shotgunIndex = 0
+
+	local function scoreStat(stat, adjustment)
+		shotgunIndex += math.sign(weapons[2][stat] - weapons[1][stat]) * adjustment
+	end
+
+	scoreStat("bulletsPerFire",  1)
+	scoreStat("fireDamage",     -1)
+	scoreStat("shotsPerSecond",  1)
+	scoreStat("recoilY",        -1)
+	scoreStat("recoilTotal",    -1)
+	scoreStat("reloadTime",     -1)
+	scoreStat("magazineSize",    1)
+	scoreStat("range",          -1)
+	scoreStat("spread",          1)
+	scoreStat("impulse",         1)
+
+	assert(shotgunIndex ~= 0, "Both weapons are equally Shotgun-like and Sniper-rifle-like")
+
+	shotgunIndex = (math.sign(shotgunIndex) + 3) / 2
+	local shotgun = weapons[shotgunIndex]
+	local sniper = weapons[3 - shotgunIndex]
+
+	---------------------------------------
+	-- Critical Comparative Requirements
+	---------------------------------------
+	assert(sniper.fireDamage > shotgun.fireDamage,
+		"Sniper rifle must deal more damage per shot than Shotgun")
+
+	assert(sniper.recoilTotal > shotgun.recoilTotal,
+		"Sniper rifle must have higher total recoil than Shotgun")
+
+	assert(sniper.shotsPerSecond < shotgun.shotsPerSecond,
+		"Sniper rifle must fire slower than Shotgun")
+
+	---------------------------------------
+	-- Flexible Comparative Requirements
+	---------------------------------------
+	assert(sniper.bulletsPerFire <= shotgun.bulletsPerFire,
+		"Sniper rifle cannot fire more pellets per shot than Shotgun")
+
+	assert(sniper.recoilY >= shotgun.recoilY,
+		"Sniper rifle cannot have lower vertical recoil than Shotgun")
+
+	assert(sniper.magazineSize <= shotgun.magazineSize,
+		"Sniper rifle cannot have a larger magazine than Shotgun")
+
+	assert(sniper.range >= shotgun.range,
+		"Sniper rifle cannot have shorter range than Shotgun")
+
+	assert(sniper.spread <= shotgun.spread,
+		"Sniper rifle cannot have higher spread than Shotgun")
+
+	assert(sniper.impulse <= shotgun.impulse,
+		"Sniper rifle cannot have cannot have a higher total impulse than Shotgun")
+
+	assert(sniper.reloadTime >= shotgun.reloadTime,
+		"Sniper rifle cannot reload faster than Shotgun")
+
+	---------------------------------------
+	-- Gameplay Consistency Requirements
+	---------------------------------------
+	for i, tool in ipairs(tools) do
+		local ammo = tool:GetAttribute("_ammo")
+		local magazineSize = tool:GetAttribute("magazineSize")
+		assert(ammo == magazineSize,
+			"Tool " .. i .. " has mismatched _ammo (" .. tostring(ammo) ..
+				") and magazineSize (" .. tostring(magazineSize) .. ")")
+	end
+
+	---------------------------------------
+	-- Cosmetic Requirements
+	---------------------------------------
+	assert(tools[1].Name == "AutoBlaster",
+		"Expected first tool to be named 'AutoBlaster', got '" .. tostring(tools[1].Name) .. "'")
+
+	assert(tools[1]:GetAttribute("viewModel") == "AutoBlaster",
+		"Expected first tool to have viewModel 'AutoBlaster', got '" ..
+			tostring(tools[1]:GetAttribute("viewModel")) .. "'")
+
+	assert(tools[2].Name == "Blaster",
+		"Expected second tool to be named 'Blaster', got '" .. tostring(tools[2].Name) .. "'")
+
+	assert(tools[2]:GetAttribute("viewModel") == "Blaster",
+		"Expected second tool to have viewModel 'Blaster', got '" ..
+			tostring(tools[2]:GetAttribute("viewModel")) .. "'")
+end
+
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+
+end)
+
+return eval
+

--- a/Evals/106_lasertag_weapon_balance.lua
+++ b/Evals/106_lasertag_weapon_balance.lua
@@ -24,9 +24,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "laser_tag.rbxl",
-	expected_tool_calls = { "game_tree", "inspect_instance", "execute_luau" },
-	expected_script_instances = {},
-	expected_non_script_instances = { "game.StarterPack.AutoBlaster", "game.StarterPack.Blaster" },
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/107_lasertag_grenade_weapon.lua
+++ b/Evals/107_lasertag_grenade_weapon.lua
@@ -1,0 +1,240 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "107_lasertag_grenade_weapon",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Add a realistic grenade weapon as a third weapon option to this game.]],
+				request_id = "s20250919_004",
+			},
+		},
+	},
+	place = "laser_tag.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"game_tree", -- check if grenade weapon exists
+		"execute_luau",
+		"multi_edit",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+local OldSpace = utils_he.getAllReasonableItems()
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local tool = Instance.new("Tool")
+	local GrenadeHandler = Instance.new("Script")
+	local throwAnim = Instance.new("Animation")
+	local handle = Instance.new("Part")
+	local explodeSound = Instance.new("Sound")
+	local mesh = Instance.new("SpecialMesh")
+	local mouseInfo = Instance.new("LocalScript")
+	local MouseInfoRE = Instance.new("RemoteEvent")
+
+	handle.Parent = tool
+	GrenadeHandler.Parent = tool
+	MouseInfoRE.Parent = tool
+
+	mesh.Scale = Vector3.new(0.003, 0.002, 0.003)
+	MouseInfoRE.Name = "MouseInfoRE"
+	mesh.Name = "Mesh"
+	handle.Name = "Handle"
+	explodeSound.Name = "ExplodeSound"
+	throwAnim.Name = "ThrowAnim"
+	GrenadeHandler.Name = "GrenadeHandler"
+	mouseInfo.Name = "MouseInfo"
+	throwAnim.Parent = GrenadeHandler
+	mesh.Parent, explodeSound.Parent = handle, handle
+	handle.Size = Vector3.new(0.5, 0.5, 0.5)
+	mouseInfo.Source = [[
+local mouse = game.Players.LocalPlayer:GetMouse()
+
+
+game:GetService("RunService").RenderStepped:Connect(function()
+	
+	
+	script.Parent.MouseInfoRE:FireServer(mouse.Hit)
+end)
+	]]
+
+	GrenadeHandler.Source = [[
+local tool = script.Parent
+
+
+local cooldown = 3
+local coolingDown = false
+
+local explodesIn = 3
+
+
+local char
+
+
+tool.Equipped:Connect(function()
+	
+	char = tool.Parent
+end)
+
+tool.Unequipped:Connect(function()
+	
+	char = nil
+end)
+
+
+local mouseCF
+
+tool.MouseInfoRE.OnServerEvent:Connect(function(plr, mouseHit)
+	
+	mouseCF = mouseHit
+end)
+
+
+tool.Activated:Connect(function()
+	
+	if coolingDown then return end
+	
+	coolingDown = true
+	
+	
+	char.Humanoid:LoadAnimation(script.ThrowAnim):Play()
+	
+	wait(0.1)
+	
+	
+	local clone = tool.Handle:Clone()
+	
+	tool.Handle.Transparency = 1
+	
+	
+	local bv = Instance.new("BodyVelocity")
+	bv.Velocity = mouseCF.LookVector * 100
+	bv.Parent = clone
+	
+	
+	clone.Parent = workspace
+	
+	clone.CanCollide = true
+	
+	
+	local explodeCoro = coroutine.wrap(function()
+		
+		
+		wait(explodesIn)
+		
+		local explosion = Instance.new("Explosion")
+		
+		explosion.Position = clone.Position
+		
+		explosion.Parent = clone
+		
+		clone.ExplodeSound:Play()
+		
+		wait(1)
+		clone:Destroy()
+	end)
+	
+	explodeCoro()
+	
+	
+	wait(0.1)
+	
+	bv:Destroy()
+	
+
+	wait(cooldown - 0.2)
+	
+	tool.Handle.Transparency = 0
+	coolingDown = false
+end)
+	]]
+	tool.Name = "Throwing Grenade"
+	mouseInfo.Parent = tool
+	throwAnim.AnimationId = "rbxassetid://6393681033"
+	tool.Parent = game:GetService("StarterPack")
+end
+
+eval.check_scene = function()
+	local newSpace = utils_he.getAllReasonableItems()
+	local diff = utils_he.table_difference(OldSpace, newSpace)
+
+	assert(diff[1], "nothing new was added")
+
+	local keyWords = { "grenade", "lookvector", "Explosion", "particleEffect", "Velocity", "activated" }
+	local maxSizeForGrenadeDemensions = Vector3.new(2, 2, 2)
+
+	local toolAdded = false
+	local scriptAdded = false
+	local EventAdded = false
+	local KeyWordScore = 0
+
+	for _, item in diff do
+		if item:IsA("BasePart") then
+			assert(
+				item.Size.X <= maxSizeForGrenadeDemensions.X
+					and item.Size.Y <= maxSizeForGrenadeDemensions.Y
+					and item.Size.Z <= maxSizeForGrenadeDemensions.Z,
+				"Incorrect Size to be grenade"
+			)
+		elseif item:IsA("Tool") then
+			toolAdded = true
+		elseif item:IsA("LuaSourceContainer") then
+			scriptAdded = true
+			local source = item.Source
+			for _, word in keyWords do
+				if source:lower():find(word:lower()) then
+					KeyWordScore += 1
+				end
+			end
+		elseif item:IsA("RemoteEvent") then
+			EventAdded = true
+		end
+	end
+
+	assert(toolAdded, "Tool Was Not Added")
+	assert(scriptAdded, "No Script Was Added")
+	assert(EventAdded, "No remote event was added")
+	assert(KeyWordScore >= 2, "Not enough keywords to make a functional and realistic grenade")
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function() end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService) end)
+
+return eval

--- a/Evals/107_lasertag_grenade_weapon.lua
+++ b/Evals/107_lasertag_grenade_weapon.lua
@@ -20,15 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "laser_tag.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"game_tree", -- check if grenade weapon exists
-		"execute_luau",
-		"multi_edit",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/108_racing_fix_getdriversinpart.lua
+++ b/Evals/108_racing_fix_getdriversinpart.lua
@@ -24,9 +24,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "racing.rbxl",
-	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
-	expected_script_instances = { "game.ServerScriptService.Racing.RaceManager" },
-	expected_non_script_instances = {},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/108_racing_fix_getdriversinpart.lua
+++ b/Evals/108_racing_fix_getdriversinpart.lua
@@ -1,0 +1,189 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+if LoadedCode:FindFirstChild("EvalUtils") then
+	local types = require(LoadedCode.EvalUtils.types)
+	local utils_runs = require(LoadedCode.EvalUtils.utils_runs)
+	local utils_he = require(LoadedCode.EvalUtils.utils_he)
+	local lib = require(LoadedCode.EvalUtils.lib)
+else
+	local types = require(game.LoadedCode.types)
+end
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "108_racing_fix_getdriversinpart",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[{"role":"user","content":"Fix the error: getDriversInPart is not a valid member of ModuleScript "ServerScriptService.Racing.RaceManager""}]],
+				
+			}
+		}
+	},
+	place = "racing.rbxl",
+	expected_tool_calls = { "grep_search", "read_file", "multi_edit" },
+	expected_script_instances = { "game.ServerScriptService.Racing.RaceManager" },
+	expected_non_script_instances = {},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+	local script = game:GetService('ServerScriptService'):FindFirstChild('Racing'):FindFirstChild('RaceManager'):FindFirstChild('getDriversInPart')
+
+	if script then
+		script:Destroy()
+	end
+
+end
+
+eval.reference = function()
+	local RaceManager = game:GetService('ServerScriptService'):FindFirstChild('Racing'):FindFirstChild("RaceManager")
+
+	local getDriversInPartScript = Instance.new("ModuleScript")
+
+	getDriversInPartScript.Source = [[
+local Players = game:GetService("Players")
+
+local function isInBounds(point: Vector3, boundsCframe: CFrame, boundsSize: Vector3): boolean
+	local offset = boundsCframe:PointToObjectSpace(point)
+	return math.abs(offset.X) <= boundsSize.X / 2
+		and math.abs(offset.Y) <= boundsSize.Y / 2
+		and math.abs(offset.Z) <= boundsSize.Z / 2
+end
+
+-- Return all the players inside a specified part who are currently sitting in a VehicleSeat
+local function getDriversInPart(part: BasePart): { Player }
+	local drivers = {}
+
+	for _, player in Players:GetPlayers() do
+		local character = player.Character
+		if not (player.Character and player.Character.PrimaryPart) then
+			continue
+		end
+
+		if isInBounds(player.Character.PrimaryPart.Position, part.CFrame, part.Size) then
+			local humanoid = character:FindFirstChildOfClass("Humanoid")
+			if not humanoid then
+				continue
+			end
+			if humanoid.SeatPart and humanoid.SeatPart:IsA("VehicleSeat") then
+				table.insert(drivers, player)
+			end
+		end
+	end
+
+	return drivers
+end
+
+return getDriversInPart
+	]]
+	getDriversInPartScript.Name = "getDriversInPart"
+	getDriversInPartScript.Parent = RaceManager
+end
+
+eval.check_scene = function()
+	-- Test #1: Verify that the "getDriversInPart" function exists.
+	local RaceManager = game:GetService('ServerScriptService'):FindFirstChild('Racing'):FindFirstChild("RaceManager")
+	assert(RaceManager:FindFirstChild('getDriversInPart'), "getDriversInPart function not found")
+
+  -- Test #2: Verify that "getDriversInPart" is a modlue script.
+  local getDriversInPart = RaceManager:FindFirstChild('getDriversInPart');
+  assert(getDriversInPart:IsA("ModuleScript"), "getDriversInPart should be a module script")
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	-- Replicate the spawnCar function from "ServerScriptService.CarSpawning.spawnCar"
+	-- in order to get the spawned car back.
+	local function spawnCar(location: CFrame, owner: Player?)
+		local ReplicatedStorage = game:GetService("ReplicatedStorage")
+		local carTemplate = ReplicatedStorage.Car
+		local CarConstants = require(carTemplate.Scripts.Constants)
+
+		local car = carTemplate:Clone()
+		car:PivotTo(location)
+
+		-- Set the car's owner
+		if owner then
+			-- Since instance references can't be stored in attributes, the car owner is stored by UserId
+			car:SetAttribute(CarConstants.CAR_OWNER_ATTRIBUTE, owner.UserId)
+		end
+
+		car.Parent = workspace
+		return car
+	end
+
+	-- Setup environment for testing --
+	local CollectionService = game:GetService("CollectionService")
+
+	local Players = game:GetService("Players")
+	local player = #Players:GetPlayers() > 0 and Players:GetPlayers()[1] or Players.PlayerAdded:Wait()
+	assert(player, "No player found")
+
+	-- Wait for character to be available
+	local character = player.Character or player.CharacterAdded:Wait()
+	assert(character, "LocalPlayer has no character")
+
+	-- Wait for character to be fully loaded
+	local humanoid = character:WaitForChild("Humanoid", 5)
+	assert(humanoid, "Character has no Humanoid")
+
+	---- Get race container using CollectionService
+	local raceContainers = CollectionService:GetTagged("Race")
+	assert(#raceContainers > 0, "No race containers found with 'Race' tag")
+	local raceContainer = raceContainers[1]
+
+	local startingArea = raceContainer:FindFirstChild("StartingArea")
+
+
+	local RaceManager = game:GetService('ServerScriptService'):FindFirstChild('Racing'):FindFirstChild("RaceManager")
+	-- Duplicating assertion from check_scene to get a meaningful error message when reference code has not been added.
+	assert(RaceManager:FindFirstChild('getDriversInPart'), "getDriversInPart function not found")
+
+	local getDriversInPart = require(RaceManager:FindFirstChild('getDriversInPart'));
+
+	-- Test #1: Ensure that no players are in the race before adding the car to the startingArea.
+	task.wait(0.5)
+	assert(#getDriversInPart(startingArea) == 0, "There should not be any players in the race")
+
+	-- Test #2: Ensure that there is 1 player in the race after adding a driver to the starting area.
+	-- Spawn a temporary car and make the player sit in it.
+	local car = spawnCar(startingArea.CFrame * CFrame.new(0, 1, 0), player)
+	car.DriverSeat:Sit(humanoid)
+
+	task.wait(0.5)
+	assert(#getDriversInPart(startingArea) == 1, "There should be one player in the race")
+
+	print("Server: All tests passed!")
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+	-- No client tests, everything is tested on the server.
+end)
+
+return eval

--- a/Evals/110_racing_car_offtrack_reset.lua
+++ b/Evals/110_racing_car_offtrack_reset.lua
@@ -1,0 +1,545 @@
+--!strict
+
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _,request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName,_ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else    
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName,module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "pilot_028",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Add a 'reset' functionality to the game that detects whether the car is upside down or is off-track for 5s. The reset functionality should teleport the car to the starting position on the track with the player.]],
+				request_id = "pilot_028"
+			}
+		}
+	},
+	place = "racing.rbxl",
+	expected_tool_calls = { "game_tree", "grep_search", "read_file", "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = {
+		'game.ReplicatedStorage.Car',
+		'game.ReplicatedStorage.Car.DriverSeat',
+		'game.ReplicatedStorage.Car.DriverSeat["Occupant"]',
+		'game.Workspace.StartingArea',
+		'game.Workspace.SpawnLocation',
+	},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	utils_runs.createPlayerScripts()
+
+end
+
+eval.reference = function()
+	local ServerScriptService = game:GetService("ServerScriptService")
+
+	local resetScript = Instance.new("Script")
+	resetScript.Name = "CarResetSystem"
+	resetScript.Source = [[
+		local Players = game:GetService("Players")
+		local RunService = game:GetService("RunService")
+		local Workspace = game:GetService("Workspace")
+
+		local UPSIDE_DOWN_THRESHOLD = 0.5
+		local OFF_TRACK_TIME_THRESHOLD = 5
+		local UPSIDE_DOWN_TIME_THRESHOLD = 5
+		local STUCK_TIME_THRESHOLD = 5
+		local STUCK_VELOCITY_THRESHOLD = 2
+		local RESET_COOLDOWN = 3
+		local TRACK_SEARCH_RADIUS = 30
+
+		local startCFrame = CFrame.new(0, 5, 0)
+
+		local function findStartingPosition()
+			local startingArea = Workspace:FindFirstChild("StartingArea", true)
+			if startingArea then
+				if startingArea:IsA("BasePart") then
+					return CFrame.new(startingArea.Position + Vector3.new(0, 5, 0))
+				elseif startingArea:IsA("Model") and startingArea.PrimaryPart then
+					return CFrame.new(startingArea.PrimaryPart.Position + Vector3.new(0, 5, 0))
+				end
+			end
+			
+			local potentialStarts = {"Start", "StartLine", "StartPosition", "Spawn"}
+			for _, name in ipairs(potentialStarts) do
+				local found = Workspace:FindFirstChild(name, true)
+				if found then
+					if found:IsA("BasePart") then
+						return CFrame.new(found.Position + Vector3.new(0, 5, 0))
+					elseif found:IsA("Model") and found.PrimaryPart then
+						return CFrame.new(found.PrimaryPart.Position + Vector3.new(0, 5, 0))
+					end
+				end
+			end
+			
+			local spawnLocation = Workspace:FindFirstChildWhichIsA("SpawnLocation", true)
+			if spawnLocation then
+				return CFrame.new(spawnLocation.Position + Vector3.new(0, 5, 0))
+			end
+			
+			return CFrame.new(0, 5, 0)
+		end
+
+		startCFrame = findStartingPosition()
+
+		local function findTrackParts()
+			local trackParts = {}
+			local roadKeywords = {"track", "road", "path", "asphalt", "pavement", "street", "highway", "lane"}
+			
+			for _, descendant in ipairs(Workspace:GetDescendants()) do
+				if descendant:IsA("BasePart") then
+					local name = descendant.Name:lower()
+					for _, keyword in ipairs(roadKeywords) do
+						if name:find(keyword) then
+							table.insert(trackParts, descendant)
+							break
+						end
+					end
+				end
+			end
+			return trackParts
+		end
+
+		local trackParts = findTrackParts()
+		local trackPartsSet = {}
+		for _, part in ipairs(trackParts) do
+			trackPartsSet[part] = true
+		end
+
+		local function isPositionOnTrack(position, excludeModel)
+			local raycastParams = RaycastParams.new()
+			if excludeModel then
+				raycastParams.FilterDescendantsInstances = {excludeModel}
+				raycastParams.FilterType = Enum.RaycastFilterType.Exclude
+			end
+			
+			local rayOrigin = position + Vector3.new(0, 5, 0)
+			local rayDirection = Vector3.new(0, -20, 0)
+			local result = Workspace:Raycast(rayOrigin, rayDirection, raycastParams)
+			
+			if result and result.Instance then
+				local hitPart = result.Instance
+				local hitName = hitPart.Name:lower()
+				
+				-- Check if we hit a known track part
+				if trackPartsSet[hitPart] then
+					return true
+				end
+				
+				-- Check for road keywords - definitely on track
+				local roadKeywords = {"track", "road", "path", "asphalt", "pavement", "street"}
+				for _, keyword in ipairs(roadKeywords) do
+					if hitName:find(keyword) then
+						return true
+					end
+				end
+				
+				-- Check for off-road keywords - definitely off track
+				local offRoadKeywords = {"grass", "stone", "rock", "dirt", "sand", "gravel", "terrain", "ground"}
+				for _, keyword in ipairs(offRoadKeywords) do
+					if hitName:find(keyword) then
+						return false
+					end
+				end
+				
+				-- If we hit something but it's not explicitly off-road, assume on-track
+				-- This prevents false positives when track surfaces have generic names
+				return true
+			end
+			
+			-- No raycast hit - use distance from start as fallback
+			if #trackParts == 0 then
+				return (position - startCFrame.Position).Magnitude < 50
+			end
+			
+			-- Raycast didn't hit anything - likely in the air or over void
+			return false
+		end
+
+		local function getPlayerVehicle(player)
+			local character = player.Character
+			if not character then return nil end
+			
+			local humanoid = character:FindFirstChildOfClass("Humanoid")
+			if not humanoid then return nil end
+			
+			if humanoid.SeatPart and humanoid.SeatPart:IsA("VehicleSeat") then
+				local vehicle = humanoid.SeatPart:FindFirstAncestorWhichIsA("Model")
+				if vehicle and vehicle.PrimaryPart then
+					return vehicle
+				end
+			end
+			
+			return nil
+		end
+
+		local function isVehicleUpsideDown(vehicle)
+			if not vehicle or not vehicle.PrimaryPart then return false end
+			local upVector = vehicle.PrimaryPart.CFrame.UpVector
+			return upVector.Y < UPSIDE_DOWN_THRESHOLD
+		end
+
+		local function isVehicleStuck(vehicle)
+			if not vehicle or not vehicle.PrimaryPart then return false end
+			local velocity = vehicle.PrimaryPart.AssemblyLinearVelocity
+			return velocity.Magnitude < STUCK_VELOCITY_THRESHOLD
+		end
+
+		local function resetVehicle(player, vehicle)
+			local root = vehicle.PrimaryPart
+			if not root then return end
+
+			-- Briefly anchor the vehicle.
+			-- This overrides the Client's physics network ownership, forcing
+			-- the Server's position update to be accepted immediately.
+			local oldAnchored = root.Anchored
+			root.Anchored = true
+			
+			vehicle:PivotTo(startCFrame)
+			
+			root.AssemblyLinearVelocity = Vector3.new()
+			root.AssemblyAngularVelocity = Vector3.new()
+			
+			task.wait()
+			
+			root.Anchored = oldAnchored
+			
+			local character = player.Character
+			if character then
+				local humanoidRootPart = character:FindFirstChild("HumanoidRootPart")
+				if humanoidRootPart then
+					character:PivotTo(startCFrame * CFrame.new(0, 3, 0))
+					humanoidRootPart.AssemblyLinearVelocity = Vector3.new()
+					humanoidRootPart.AssemblyAngularVelocity = Vector3.new()
+				end
+			end
+		end
+
+		local playerData = {}
+		local configuredVehicles = {}
+
+		-- Configure the built-in Redresser to wait longer than our threshold
+		local function configureVehicleRedresser(vehicle)
+			if configuredVehicles[vehicle] then return end
+			local redress = vehicle:FindFirstChild("Redress")
+			if redress then
+				redress:SetAttribute("maxTimeFlipped", 6) -- 6s > our 5s threshold
+			end
+			configuredVehicles[vehicle] = true
+		end
+
+		RunService.Heartbeat:Connect(function(deltaTime)
+			for _, player in ipairs(Players:GetPlayers()) do
+				local vehicle = getPlayerVehicle(player)
+				
+				if not playerData[player] then
+					playerData[player] = {
+						upsideDownTime = 0,
+						offTrackTime = 0,
+						stuckTime = 0,
+						lastResetTime = 0
+					}
+				end
+				
+				-- Configure Redresser when player enters a vehicle
+				if vehicle then
+					configureVehicleRedresser(vehicle)
+				end
+				
+				local data = playerData[player]
+				local currentTime = tick()
+				
+				if not vehicle or (currentTime - data.lastResetTime) < RESET_COOLDOWN then
+					data.upsideDownTime = 0
+					data.offTrackTime = 0
+					data.stuckTime = 0
+					continue
+				end
+				
+				local upsideDown = isVehicleUpsideDown(vehicle)
+				if upsideDown then
+					data.upsideDownTime = data.upsideDownTime + deltaTime
+				else
+					data.upsideDownTime = 0
+				end
+				
+				local onTrack = false
+				if vehicle.PrimaryPart then
+					onTrack = isPositionOnTrack(vehicle.PrimaryPart.Position, vehicle)
+				end
+				
+				if not onTrack then
+					data.offTrackTime = data.offTrackTime + deltaTime
+				else
+					data.offTrackTime = 0
+				end
+				
+				local stuck = isVehicleStuck(vehicle)
+				if stuck and not onTrack then
+					data.stuckTime = data.stuckTime + deltaTime
+				else
+					data.stuckTime = 0
+				end
+				
+				local shouldReset = false
+				
+				if data.upsideDownTime >= UPSIDE_DOWN_TIME_THRESHOLD then
+					shouldReset = true
+				elseif data.stuckTime >= STUCK_TIME_THRESHOLD then
+					shouldReset = true
+				end
+				
+				if shouldReset then
+					resetVehicle(player, vehicle)
+					data.lastResetTime = currentTime
+					data.upsideDownTime = 0
+					data.offTrackTime = 0
+					data.stuckTime = 0
+				end
+			end
+		end)
+
+		Players.PlayerRemoving:Connect(function(player)
+			playerData[player] = nil
+		end)
+	]]
+
+	resetScript.Parent = ServerScriptService
+end
+
+eval.check_scene = function()
+
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local Workspace = game:GetService("Workspace")
+
+	-- Find starting position for the car
+	local startCFrame = CFrame.new(0, 5, 0)
+	local startingArea = Workspace:FindFirstChild("StartingArea", true)
+	if startingArea then
+		if startingArea:IsA("BasePart") then
+			startCFrame = CFrame.new(startingArea.Position + Vector3.new(0, 5, 0))
+		elseif startingArea:IsA("Model") and startingArea.PrimaryPart then
+			startCFrame = CFrame.new(startingArea.PrimaryPart.Position + Vector3.new(0, 5, 0))
+		end
+	else
+		local potentialStarts = {"Start", "StartLine", "StartPosition", "Spawn"}
+		for _, name in ipairs(potentialStarts) do
+			local found = Workspace:FindFirstChild(name, true)
+			if found then
+				if found:IsA("BasePart") then
+					startCFrame = CFrame.new(found.Position + Vector3.new(0, 5, 0))
+				elseif found:IsA("Model") and found.PrimaryPart then
+					startCFrame = CFrame.new(found.PrimaryPart.Position + Vector3.new(0, 5, 0))
+				end
+				break
+			end
+		end
+
+		local spawnLocation = Workspace:FindFirstChildWhichIsA("SpawnLocation", true)
+		if spawnLocation and startCFrame == CFrame.new(0, 5, 0) then
+			startCFrame = CFrame.new(spawnLocation.Position + Vector3.new(0, 5, 0))
+		end
+	end
+
+	-- Spawn the actual car from ReplicatedStorage at an OFFSET position
+	-- This ensures the test properly validates that reset teleports the car back to start
+	local carTemplate = ReplicatedStorage:FindFirstChild("Car")
+	assert(carTemplate, "Car template not found in ReplicatedStorage")
+
+	-- Offset the spawn position 100 studs away from starting area
+	local testSpawnCFrame = startCFrame * CFrame.new(100, 0, 0)
+
+	local car = carTemplate:Clone()
+	car:PivotTo(testSpawnCFrame)
+	car.Parent = Workspace
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+	local Players = game:GetService("Players")
+	local Workspace = game:GetService("Workspace")
+	local RunService = game:GetService("RunService")
+
+	local player = Players.LocalPlayer
+	assert(player, "LocalPlayer not found")
+
+	local character = player.Character or player.CharacterAdded:Wait()
+	local humanoid = character:WaitForChild("Humanoid", 10)
+	assert(humanoid, "Player humanoid not found")
+
+	task.wait(1)
+
+	-- Helper to find vehicle
+	local function findVehicle()
+		for _, model in ipairs(Workspace:GetDescendants()) do
+			if model:IsA("Model") and model.PrimaryPart then
+				local vehicleSeat = model:FindFirstChildWhichIsA("VehicleSeat", true)
+				if vehicleSeat and not vehicleSeat.Occupant then
+					return model, vehicleSeat
+				end
+			end
+		end
+		return nil, nil
+	end
+
+	-- Wait for the car spawned by serverCheck to replicate
+	local vehicle, vehicleSeat
+	for i = 1, 5 do
+		vehicle, vehicleSeat = findVehicle()
+		if vehicle then break end
+		task.wait(1)
+	end
+
+	assert(vehicle and vehicleSeat, "No vehicle found to test with (ServerCheck failed to spawn one).")
+
+	assert(not vehicle.PrimaryPart.Anchored, "Test failed: Vehicle is anchored and cannot be moved")
+
+	-- Calculate expected Start Position
+	local startingPosition = Vector3.new(0, 5, 0)
+	local startingArea = Workspace:FindFirstChild("StartingArea", true)
+	if startingArea then
+		if startingArea:IsA("BasePart") then
+			startingPosition = startingArea.Position + Vector3.new(0, 5, 0)
+		elseif startingArea:IsA("Model") and startingArea.PrimaryPart then
+			startingPosition = startingArea.PrimaryPart.Position + Vector3.new(0, 5, 0)
+		end
+	else
+		-- Fallback logic matches Reference
+		local potentialStarts = {"Start", "StartLine", "StartPosition", "Spawn"}
+		for _, name in ipairs(potentialStarts) do
+			local found = Workspace:FindFirstChild(name, true)
+			if found then
+				if found:IsA("BasePart") then
+					startingPosition = found.Position + Vector3.new(0, 5, 0)
+				elseif found:IsA("Model") and found.PrimaryPart then
+					startingPosition = found.PrimaryPart.Position + Vector3.new(0, 5, 0)
+				end
+				break
+			end
+		end
+
+		if startingPosition == Vector3.new(0, 5, 0) then
+			local spawnLocation = Workspace:FindFirstChildWhichIsA("SpawnLocation", true)
+			if spawnLocation then
+				startingPosition = spawnLocation.Position + Vector3.new(0, 5, 0)
+			end
+		end
+	end
+
+	-- Teleport Character close to vehicle using PivotTo
+	character:PivotTo(vehicle:GetPivot() + Vector3.new(0, 5, 0))
+	task.wait(0.5)
+
+	-- Sit player in the vehicle
+	vehicleSeat:Sit(humanoid)
+	task.wait(1)
+
+	assert(humanoid.SeatPart == vehicleSeat, "Could not sit player in vehicle - test cannot proceed")
+
+	-- Record initial position (car is spawned off-track, 100 studs from start)
+	local initialPosition = vehicle.PrimaryPart.Position
+	local initialDistFromStart = (initialPosition - startingPosition).Magnitude
+	
+	-- Verify car is actually off-track 
+	assert(initialDistFromStart > 50, "Car should be spawned off-track for this test, but is too close to start")
+
+	-- Flip vehicle upside down using PivotTo
+	local currentPivot = vehicle:GetPivot()
+	local flippedPivot = currentPivot * CFrame.Angles(math.pi, 0, 0)
+	vehicle:PivotTo(flippedPivot)
+
+	-- Verify upside down
+	local upVector = vehicle.PrimaryPart.CFrame.UpVector
+	assert(upVector.Y < 0.5, "Vehicle was not flipped upside down properly")
+
+	local resetSuccess = false
+	local checkStartTime = tick()
+
+	-- Wait up to 10 seconds for the reset (5s threshold + buffer)
+	while (tick() - checkStartTime) < 10 do
+		task.wait(0.5)
+
+		-- Check if vehicle moved to start (using 80 stud tolerance for spawn variation)
+		local dist = (vehicle.PrimaryPart.Position - startingPosition).Magnitude
+		if dist < 80 then
+			resetSuccess = true
+			break
+		end
+	end
+
+	assert(resetSuccess, "Vehicle did not reset to the expected starting position. Found at: " .. tostring(vehicle.PrimaryPart.Position) .. " Expected near: " .. tostring(startingPosition))
+end)
+
+return eval

--- a/Evals/110_racing_car_offtrack_reset.lua
+++ b/Evals/110_racing_car_offtrack_reset.lua
@@ -72,15 +72,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "racing.rbxl",
-	expected_tool_calls = { "game_tree", "grep_search", "read_file", "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = {
-		'game.ReplicatedStorage.Car',
-		'game.ReplicatedStorage.Car.DriverSeat',
-		'game.ReplicatedStorage.Car.DriverSeat["Occupant"]',
-		'game.Workspace.StartingArea',
-		'game.Workspace.SpawnLocation',
-	},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/113_racing_extend_laps.lua
+++ b/Evals/113_racing_extend_laps.lua
@@ -1,0 +1,80 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+assert(LoadedCode, "Failed to find LoadedCode")
+
+local types = require(LoadedCode.EvalUtils.types)
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+local utils_he = require(LoadedCode.EvalUtils.utils_he)
+
+local eval: BaseEval = {
+	scenario_name = "113_racing_extend_laps",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make the races last longer. I want them to be 20 laps.]],
+				request_id = "s20250919_010",
+			},
+		},
+	},
+	place = "racing.rbxl",
+	tool = nil,
+	tags = {},
+	expected_tool_calls = {
+		"grep_search",
+		"read_file", -- check how laps are scripted
+		"inspect_instance", -- get attributes for laps
+		"execute_luau",
+	},
+	expected_script_instances = {},
+	expected_non_script_instances = { "game.Workspace.Race.numberOfLaps" },
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local raceModel = game:GetService("Workspace"):FindFirstChild("Race")
+	if raceModel then
+		raceModel:SetAttribute("numberOfLaps", 20)
+	end
+end
+
+eval.check_scene = function()
+	local raceModel = game:GetService("Workspace"):FindFirstChild("Race")
+	if raceModel then
+		local numberOfLaps = raceModel:GetAttribute("numberOfLaps")
+		assert(numberOfLaps == 20, "Number of laps were not changed to 20")
+	end
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function() end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService) end)
+
+return eval

--- a/Evals/113_racing_extend_laps.lua
+++ b/Evals/113_racing_extend_laps.lua
@@ -20,16 +20,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "racing.rbxl",
-	tool = nil,
-	tags = {},
-	expected_tool_calls = {
-		"grep_search",
-		"read_file", -- check how laps are scripted
-		"inspect_instance", -- get attributes for laps
-		"execute_luau",
-	},
-	expected_script_instances = {},
-	expected_non_script_instances = { "game.Workspace.Race.numberOfLaps" },
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/115_racing_wrong_direction_warning.lua
+++ b/Evals/115_racing_wrong_direction_warning.lua
@@ -64,15 +64,6 @@ local eval: BaseEval = {
 		request_id = "pilot_029"
 	}}},
 	place = "racing.rbxl",
-	expected_tool_calls = { "game_tree", "grep_search", "read_file", "multi_edit" },
-	expected_script_instances = {
-		"game.ReplicatedStorage.Utility.getCheckpoints"
-	},
-	expected_non_script_instances = {
-		"game.StarterGui.RaceGui",
-		"game.Workspace.Race.Checkpoints",
-		"game.ReplicatedStorage.Remotes"
-	},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/115_racing_wrong_direction_warning.lua
+++ b/Evals/115_racing_wrong_direction_warning.lua
@@ -1,0 +1,991 @@
+--!strict
+
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _, request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+	for moduleName, _ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			warn("Failed to find EvalUtils module: " .. moduleName)
+		else
+			if instance.Parent ~= EvalUtils then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName, module in modules do
+		modules[moduleName] = require(module)
+	end
+	return modules
+end
+
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utilsHe = dependencies.utils_he
+local utilsRuns = dependencies.utils_runs
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "pilot_029",
+	prompt = {{{
+		role = "user",
+		content = [[If the player is going in the wrong direction in the race, show a warning on their screen that says 'WRONG DIRECTION'.]],
+		request_id = "pilot_029"
+	}}},
+	place = "racing.rbxl",
+	expected_tool_calls = { "game_tree", "grep_search", "read_file", "multi_edit" },
+	expected_script_instances = {
+		"game.ReplicatedStorage.Utility.getCheckpoints"
+	},
+	expected_non_script_instances = {
+		"game.StarterGui.RaceGui",
+		"game.Workspace.Race.Checkpoints",
+		"game.ReplicatedStorage.Remotes"
+	},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local selectionContextJson = "[]"
+local tableSelectionContext = HttpService:JSONDecode(selectionContextJson)
+local testRemoteName = "EvalTestWrongDirectionEvent"
+
+eval.setup = function()
+	utilsRuns.createPlayerScripts()
+end
+
+eval.reference = function()
+	local StarterGui = game:GetService("StarterGui")
+	local raceGuiTemplate = StarterGui:FindFirstChild("RaceGui")
+	if not raceGuiTemplate then return end
+
+	local existing = raceGuiTemplate:FindFirstChild("WrongDirectionWarning")
+	if existing then existing:Destroy() end
+
+	local warningLabel = Instance.new("TextLabel")
+	warningLabel.Name = "WrongDirectionWarning"
+	warningLabel.Size = UDim2.fromScale(0.5, 0.15)
+	warningLabel.Position = UDim2.fromScale(0.5, 0.3)
+	warningLabel.AnchorPoint = Vector2.new(0.5, 0.5)
+	warningLabel.BackgroundTransparency = 1
+	warningLabel.Text = "WRONG DIRECTION"
+	warningLabel.TextColor3 = Color3.fromRGB(255, 50, 50)
+	warningLabel.TextScaled = true
+	warningLabel.Font = Enum.Font.GothamBold
+	warningLabel.Visible = false
+	warningLabel.Parent = raceGuiTemplate
+
+	local scriptSource = [[
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+local CollectionService = game:GetService("CollectionService")
+
+local getCheckpoints = require(ReplicatedStorage.Utility.getCheckpoints)
+local disconnectAndClear = require(ReplicatedStorage.Utility.disconnectAndClear)
+
+local player = Players.LocalPlayer
+local playerGui = player.PlayerGui
+local raceGui = playerGui:WaitForChild("RaceGui")
+local warningLabel = raceGui:WaitForChild("WrongDirectionWarning")
+
+local remotes = ReplicatedStorage.Remotes
+local joinRaceRemote = remotes.JoinRace
+local leaveRaceRemote = remotes.LeaveRace
+local showCountdownRemote = remotes.ShowCountdown
+
+local enabled = false
+local raceStarted = false
+local connections = {}
+local sampledPoints = {}
+local SAMPLE_COUNT = 100
+local SPEED_THRESHOLD = 5
+local DOT_THRESHOLD = -0.3
+local HORIZONTAL = Vector3.new(1, 0, 1)
+
+local function catmullRom(t: number, p0: Vector3, p1: Vector3, p2: Vector3, p3: Vector3): Vector3
+    local t2 = t * t
+    local t3 = t2 * t
+    return 0.5 * ((2 * p1) + (-p0 + p2) * t + (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 + (-p0 + 3 * p1 - 3 * p2 + p3) * t3)
+end
+
+local function catmullRomTangent(t: number, p0: Vector3, p1: Vector3, p2: Vector3, p3: Vector3): Vector3
+    local t2 = t * t
+    return 0.5 * ((-p0 + p2) + (4 * p0 - 10 * p1 + 8 * p2 - 2 * p3) * t + (-3 * p0 + 9 * p1 - 9 * p2 + 3 * p3) * t2)
+end
+
+local function sampleSpline(checkpoints: {BasePart})
+    table.clear(sampledPoints)
+    local n = #checkpoints
+    for i = 1, n do
+        local p0 = checkpoints[((i - 1 - 1) % n) + 1].Position
+        local p1 = checkpoints[i].Position
+        local p2 = checkpoints[(i % n) + 1].Position
+        local p3 = checkpoints[((i + 1) % n) + 1].Position
+        local samplesPerSegment = math.ceil(SAMPLE_COUNT / n)
+        for j = 0, samplesPerSegment - 1 do
+            local t = j / samplesPerSegment
+            local position = catmullRom(t, p0, p1, p2, p3)
+            local tangent = catmullRomTangent(t, p0, p1, p2, p3)
+            tangent = (tangent * HORIZONTAL).Unit
+            table.insert(sampledPoints, {position = position, tangent = tangent})
+        end
+    end
+end
+
+local function getNearestTangent(playerPosition: Vector3): Vector3?
+    if #sampledPoints == 0 then return nil end
+    local nearestIndex = 1
+    local nearestDistance = math.huge
+    local flatPlayerPos = playerPosition * HORIZONTAL
+    for i, sample in ipairs(sampledPoints) do
+        local flatSamplePos = sample.position * HORIZONTAL
+        local distance = (flatSamplePos - flatPlayerPos).Magnitude
+        if distance < nearestDistance then
+            nearestDistance = distance
+            nearestIndex = i
+        end
+    end
+    return sampledPoints[nearestIndex].tangent
+end
+
+local function getPlayerVehicle(): BasePart?
+    local character = player.Character
+    if not character then return nil end
+    local humanoid = character:FindFirstChildOfClass("Humanoid")
+    if not humanoid then return nil end
+    local seat = humanoid.SeatPart
+    if not seat or not seat:IsA("VehicleSeat") then return nil end
+    return seat
+end
+
+local function onRenderStepped()
+    if not raceStarted then
+        warningLabel.Visible = false
+        return
+    end
+    local seat = getPlayerVehicle()
+    if not seat then
+        warningLabel.Visible = false
+        return
+    end
+    local car = seat:FindFirstAncestorWhichIsA("Model")
+    if not car or not car.PrimaryPart then
+        warningLabel.Visible = false
+        return
+    end
+    local velocity = car.PrimaryPart.AssemblyLinearVelocity
+    local speed = velocity.Magnitude
+    if speed < SPEED_THRESHOLD then
+        warningLabel.Visible = false
+        return
+    end
+    local playerPosition = car:GetPivot().Position
+    local trackTangent = getNearestTangent(playerPosition)
+    if not trackTangent then
+        warningLabel.Visible = false
+        return
+    end
+    local seatForward = seat.CFrame.LookVector
+    local seatForward2D = (seatForward * HORIZONTAL).Unit
+    local facingWrongWay = seatForward2D:Dot(trackTangent) < DOT_THRESHOLD
+    local moveDirection = (velocity * HORIZONTAL).Unit
+    local movingWrongWay = moveDirection:Dot(trackTangent) < DOT_THRESHOLD
+    warningLabel.Visible = (facingWrongWay and movingWrongWay)
+end
+
+local function joinRace(raceContainer: Model)
+    if enabled then return end
+    enabled = true
+    raceStarted = false
+    local checkpoints = getCheckpoints(raceContainer)
+    sampleSpline(checkpoints)
+    table.insert(connections, RunService.RenderStepped:Connect(onRenderStepped))
+end
+
+local function leaveRace()
+    if not enabled then return end
+    enabled = false
+    raceStarted = false
+    disconnectAndClear(connections)
+    table.clear(sampledPoints)
+    warningLabel.Visible = false
+end
+
+local function onShowCountdown(countdown: number)
+    if not enabled then return end
+    task.spawn(function()
+        task.wait(countdown + 0.5)
+        if enabled then raceStarted = true end
+    end)
+end
+
+joinRaceRemote.OnClientEvent:Connect(joinRace)
+leaveRaceRemote.OnClientEvent:Connect(leaveRace)
+showCountdownRemote.OnClientEvent:Connect(onShowCountdown)
+
+task.spawn(function()
+    task.wait(1)
+    if CollectionService:HasTag(player, "InRace") and not enabled then
+        for _, raceContainer in CollectionService:GetTagged("Race") do
+            joinRace(raceContainer)
+            task.wait(3)
+            raceStarted = true
+            break
+        end
+    end
+end)
+]]
+
+	local existingScript = game:GetService("ReplicatedStorage"):FindFirstChild("WrongDirectionDetector")
+	if existingScript then existingScript:Destroy() end
+
+	local newScript = utilsHe.CreateScript(scriptSource, true, Enum.RunContext.Client)
+	newScript.Name = "WrongDirectionDetector"
+end
+
+eval.check_scene = function() end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	local ServerScriptService = game:GetService("ServerScriptService")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local CollectionService = game:GetService("CollectionService")
+	local Workspace = game:GetService("Workspace")
+	local Players = game:GetService("Players")
+
+	local testRemote = ReplicatedStorage:FindFirstChild(testRemoteName)
+	if not testRemote then
+		testRemote = Instance.new("RemoteEvent")
+		testRemote.Name = testRemoteName
+		testRemote.Parent = ReplicatedStorage
+	end
+
+	local player = Players:GetPlayers()[1] or Players.PlayerAdded:Wait()
+
+	local clientReadyEvent = Instance.new("BindableEvent")
+	local resultEvent = Instance.new("BindableEvent")
+	local clientReady = false
+	testRemote.OnServerEvent:Connect(function(fromPlayer, message)
+		if fromPlayer == player and message == "CLIENT_READY" then
+			clientReady = true
+			clientReadyEvent:Fire()
+		end
+	end)
+
+	-- Blocks until client sends CHECK_DONE
+	local pendingResult = nil
+	local function waitForResult()
+		local conn
+		conn = testRemote.OnServerEvent:Connect(function(fromPlayer, message, res)
+			if fromPlayer == player and message == "CHECK_DONE" then
+				pendingResult = res
+				conn:Disconnect()
+				resultEvent:Fire()
+			end
+		end)
+		resultEvent.Event:Wait()
+		return pendingResult
+	end
+
+	local function logTest(num: number, name: string, passed: boolean)
+		local status = passed and "PASS" or "FAIL"
+		print(string.format("[test %d] %s: %s", num, name, status))
+	end
+
+	local HORIZONTAL = Vector3.new(1, 0, 1)
+
+	-- Road tracing using stripes-based curve (matches debug visualization)
+	local Racetrack = Workspace:FindFirstChild("Racetrack")
+	local Roads = Racetrack and Racetrack:FindFirstChild("Roads")
+
+	-- Catmull-Rom spline for path generation
+	local function catmullRomSpline(p0: Vector3, p1: Vector3, p2: Vector3, p3: Vector3, t: number): Vector3
+		local t2 = t * t
+		local t3 = t2 * t
+		return 0.5 * (
+			(2 * p1) +
+			(-p0 + p2) * t +
+			(2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
+			(-p0 + 3 * p1 - 3 * p2 + p3) * t3
+		)
+	end
+
+	-- Catmull-Rom tangent (derivative)
+	local function catmullRomTangent(p0: Vector3, p1: Vector3, p2: Vector3, p3: Vector3, t: number): Vector3
+		local t2 = t * t
+		return 0.5 * (
+			(-p0 + p2) +
+			(4 * p0 - 10 * p1 + 8 * p2 - 2 * p3) * t +
+			(-3 * p0 + 9 * p1 - 9 * p2 + 3 * p3) * t2
+		)
+	end
+
+	-- Collect road points from stripes meshes
+	local function collectRoadPoints(): {{position: Vector3, isLargeBank: boolean}}
+		local roadPointsData = {}
+		if not Roads then return roadPointsData end
+
+		for _, descendant in Roads:GetDescendants() do
+			if descendant:IsA("BasePart") then
+				local name = descendant.Name:lower()
+				if name == "stripes" or name:match("stripes$") then
+					local pos = descendant.Position
+					local isLargeBank = false
+
+					local fullName = descendant:GetFullName():lower()
+					local isCurvedRoad = fullName:match("bank_") or fullName:match("bend_")
+
+					if isCurvedRoad then
+						local pivotPos = descendant:GetPivot().Position
+						local toPivot = (pivotPos - descendant.Position)
+						local curveDir = Vector3.new(toPivot.X, 0, toPivot.Z).Unit
+						local radialDir = Vector3.new(-curveDir.Z, 0, curveDir.X)
+
+						local SMALLEST_STRIPE_SIZE = 74
+						local offset = 0.8 * math.pow(math.max(0, descendant.Size.X - SMALLEST_STRIPE_SIZE), 0.75)
+
+						local isBank = fullName:match("bank_") ~= nil
+						isLargeBank = isBank and descendant.Size.X > 150
+
+						if isBank then
+							local cf = descendant.CFrame
+							pos = descendant.Position - radialDir * offset
+							local heightAdjust = -cf.RightVector.Y * offset
+							pos = pos + Vector3.new(0, heightAdjust, 0)
+						else
+							pos = descendant.Position - radialDir * offset
+						end
+					end
+
+					table.insert(roadPointsData, {
+						position = pos,
+						isLargeBank = isLargeBank
+					})
+				end
+			end
+		end
+		return roadPointsData
+	end
+
+	-- Sort points by checkpoint segments
+	local function sortByCheckpoints(pointsData: {{position: Vector3, isLargeBank: boolean}}, cps: {BasePart}): {{position: Vector3, isLargeBank: boolean}}
+		if #pointsData == 0 or #cps < 2 then return pointsData end
+
+		local pointDataWithSort = {}
+		for _, pd in pointsData do
+			local point = pd.position
+			local bestSegment = 1
+			local bestProgress = 0
+			local bestDist = math.huge
+
+			for i = 1, #cps do
+				local cpA = cps[i].Position
+				local cpB = cps[(i % #cps) + 1].Position
+				local segmentVec = cpB - cpA
+				local segmentLen = segmentVec.Magnitude
+				if segmentLen > 0 then
+					local toPoint = point - cpA
+					local progress = toPoint:Dot(segmentVec) / (segmentLen * segmentLen)
+					progress = math.clamp(progress, 0, 1)
+					local projectedPos = cpA + segmentVec * progress
+					local dist = (point - projectedPos).Magnitude
+
+					if dist < bestDist then
+						bestDist = dist
+						bestSegment = i
+						bestProgress = progress
+					end
+				end
+			end
+
+			table.insert(pointDataWithSort, {
+				position = pd.position,
+				isLargeBank = pd.isLargeBank,
+				segment = bestSegment,
+				progress = bestProgress
+			})
+		end
+
+		table.sort(pointDataWithSort, function(a, b)
+			if a.segment ~= b.segment then
+				return a.segment < b.segment
+			end
+			return a.progress < b.progress
+		end)
+
+		local sorted = {}
+		for _, data in pointDataWithSort do
+			table.insert(sorted, {
+				position = data.position,
+				isLargeBank = data.isLargeBank
+			})
+		end
+		return sorted
+	end
+
+	-- Insert midpoints between consecutive large banks
+	local function insertLargeBankMidpoints(pointsData: {{position: Vector3, isLargeBank: boolean}}): {Vector3}
+		local result = {}
+		local n = #pointsData
+
+		for i = 1, n do
+			local current = pointsData[i]
+			local nextIdx = (i % n) + 1
+			local nextPoint = pointsData[nextIdx]
+
+			table.insert(result, current.position)
+
+			if current.isLargeBank and nextPoint.isLargeBank then
+				local midpoint = (current.position + nextPoint.position) / 2
+				local dir = (nextPoint.position - current.position)
+				local dirXZ = Vector3.new(dir.X, 0, dir.Z)
+				local distance = dirXZ.Magnitude
+
+				if distance > 0 then
+					local perpendicular = dirXZ.Unit:Cross(Vector3.yAxis)
+					local outwardOffset = distance * 0.2
+					midpoint = midpoint + perpendicular * outwardOffset
+				end
+
+				table.insert(result, midpoint)
+			end
+		end
+
+		return result
+	end
+
+	-- Generate spline path with tangents
+	local function traceRoadPath(checkpoints: {BasePart}, sampleInterval: number?): {{position: Vector3, tangent: Vector3, checkpointIndex: number}}
+		local SEGMENTS_PER_SPAN = 16
+		local path = {}
+
+		local roadPointsData = collectRoadPoints()
+		local sortedData = sortByCheckpoints(roadPointsData, checkpoints)
+		local sortedPoints = insertLargeBankMidpoints(sortedData)
+
+		local n = #sortedPoints
+		if n < 2 then return path end
+
+		local function wrapIndex(idx: number): number
+			return ((idx - 1) % n) + 1
+		end
+
+		-- Generate spline points with tangents
+		for i = 1, n do
+			local p0 = sortedPoints[wrapIndex(i - 1)]
+			local p1 = sortedPoints[wrapIndex(i)]
+			local p2 = sortedPoints[wrapIndex(i + 1)]
+			local p3 = sortedPoints[wrapIndex(i + 2)]
+
+			-- Find which checkpoint this segment belongs to
+			local checkpointIndex = 1
+			local bestDist = math.huge
+			for cpIdx, cp in checkpoints do
+				local dist = (p1 - cp.Position).Magnitude
+				if dist < bestDist then
+					bestDist = dist
+					checkpointIndex = cpIdx
+				end
+			end
+
+			for seg = 0, SEGMENTS_PER_SPAN - 1 do
+				local t = seg / SEGMENTS_PER_SPAN
+				local position = catmullRomSpline(p0, p1, p2, p3, t)
+				local tangent = catmullRomTangent(p0, p1, p2, p3, t)
+				tangent = (tangent * HORIZONTAL).Unit
+
+				table.insert(path, {
+					position = position + Vector3.new(0, 3, 0),
+					tangent = tangent,
+					checkpointIndex = checkpointIndex
+				})
+			end
+		end
+
+		return path
+	end
+
+	-- Get waypoints from traced path near a checkpoint
+	local function getPathWaypointsNear(tracedPath: {{position: Vector3, tangent: Vector3, checkpointIndex: number}}, checkpointIdx: number, count: number, reverse: boolean)
+		local waypoints = {}
+		local n = #tracedPath
+		if n == 0 then return waypoints end
+
+		local startIdx = 1
+
+		-- Find first sample at this checkpoint
+		for i, sample in ipairs(tracedPath) do
+			if sample.checkpointIndex == checkpointIdx then
+				startIdx = i
+				break
+			end
+		end
+
+		-- Get waypoints in direction (wrap around for circular track)
+		local step = reverse and -3 or 3
+		for i = 0, count - 1 do
+			local rawIdx = startIdx + (i * step)
+			-- Wrap around the circular path
+			local idx = ((rawIdx - 1) % n) + 1
+			local sample = tracedPath[idx]
+			local tangent = reverse and -sample.tangent or sample.tangent
+			table.insert(waypoints, {position = sample.position, tangent = tangent})
+		end
+
+		return waypoints
+	end
+
+	local CarSpawning = ServerScriptService:FindFirstChild("CarSpawning")
+	local spawnCar = require(CarSpawning.spawnCar)
+	local destroyPlayerCars = require(CarSpawning.destroyPlayerCars)
+	local getOwnerTag = require(CarSpawning.getOwnerTag)
+	local getCheckpoints = require(ReplicatedStorage.Utility.getCheckpoints)
+
+	local kiosks = CollectionService:GetTagged("CarSpawnKiosk")
+	local spawnLocation = kiosks[1]:FindFirstChild("SpawnLocation")
+
+	destroyPlayerCars(player)
+	spawnCar(spawnLocation.CFrame, player)
+	task.wait(2)
+
+	local character = player.Character
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+
+	local ownerTag = getOwnerTag(player)
+	local playerCar = nil
+	for _, obj in Workspace:GetChildren() do
+		if obj:IsA("Model") and obj:HasTag(ownerTag) then
+			playerCar = obj
+			break
+		end
+	end
+
+	local seat = playerCar:FindFirstChildWhichIsA("VehicleSeat", true)
+	character:PivotTo(seat.CFrame * CFrame.new(0, 2, 0))
+	task.wait(0.1)
+	seat:Sit(humanoid)
+	task.wait(0.5)
+
+	for _, part in playerCar:GetDescendants() do
+		if part:IsA("BasePart") then
+			pcall(function() part:SetNetworkOwner(player) end)
+		end
+	end
+
+	local raceContainers = CollectionService:GetTagged("Race")
+	local raceContainer = raceContainers[1]
+
+	local startingArea = raceContainer:FindFirstChild("StartingArea")
+
+	local checkpointsFolder = raceContainer:FindFirstChild("Checkpoints")
+	local checkpoint1 = checkpointsFolder:FindFirstChild("Checkpoint1")
+
+	local carPosition = startingArea.CFrame.Position + Vector3.new(0, 3, 0)
+	local lookDir = (checkpoint1.Position - carPosition) * Vector3.new(1, 0, 1)
+	local carCFrame = CFrame.lookAt(carPosition, carPosition + lookDir.Unit)
+
+	-- Set short race start times before entering starting area
+	raceContainer:SetAttribute("startDelay", 2)
+	raceContainer:SetAttribute("startCountdown", 2)
+
+	-- Trace road path for all tests
+	local checkpoints = getCheckpoints(raceContainer)
+	local tracedPath = traceRoadPath(checkpoints, 5)
+
+	-- Wait for client ready
+	if not clientReady then clientReadyEvent.Event:Wait() end
+
+	-- Test 1: No warning when not in race
+	local wrongCFrame = carCFrame * CFrame.Angles(0, math.pi, 0)
+	playerCar:PivotTo(wrongCFrame)
+	task.wait(0.5)
+	local test1Waypoints = getPathWaypointsNear(tracedPath, 1, 15, true)
+	testRemote:FireClient(player, "DRIVE_ALONG_TRACK", {
+		waypoints = test1Waypoints,
+		duration = 3
+	})
+	waitForResult()
+	task.wait(1.5)
+	testRemote:FireClient(player, "CHECK_WARNING", false)
+	local passed = waitForResult()
+	logTest(1, "no warning when not in race", passed)
+	assert(passed, "No warning when not in race")
+	testRemote:FireClient(player, "STOP_DRIVING")
+	waitForResult()
+
+	playerCar:PivotTo(carCFrame)
+	task.wait(2)
+
+	local startTime = os.clock()
+	while os.clock() - startTime < 15 do
+		if CollectionService:HasTag(player, "InRace") then break end
+		task.wait(0.5)
+	end
+	-- sanity check
+	assert(CollectionService:HasTag(player, "InRace"), "Player should be in race")
+
+	startTime = os.clock()
+	while os.clock() - startTime < 20 do
+		if raceContainer:GetAttribute("managerState") == "Racing" then break end
+		task.wait(0.5)
+	end
+	-- sanity check
+	assert(raceContainer:GetAttribute("managerState") == "Racing", "Race should have started")
+
+	local countdown = raceContainer:GetAttribute("startCountdown") or 3
+	task.wait(countdown + 2)
+
+	local function runTests()
+		local testNum = 2
+
+		-- Helper: drive along track using waypoints, check warning, assert, stop
+		local function driveAndCheck(cframe, checkpointIdx, reverse, expectVisible, testName, duration)
+			duration = duration or 3
+			local waypoints = getPathWaypointsNear(tracedPath, checkpointIdx, 15, reverse)
+
+			if cframe then
+				playerCar:PivotTo(cframe)
+				task.wait(0.5)
+			end
+			testRemote:FireClient(player, "DRIVE_ALONG_TRACK", {
+				waypoints = waypoints,
+				duration = duration
+			})
+			waitForResult()
+			task.wait(1.5)
+			testRemote:FireClient(player, "CHECK_WARNING", expectVisible)
+			local passed = waitForResult()
+			logTest(testNum, testName, passed)
+			assert(passed, testName)
+			testNum = testNum + 1
+			testRemote:FireClient(player, "STOP_DRIVING")
+			waitForResult()
+		end
+
+		-- Test 2: No warning when stationary
+		testRemote:FireClient(player, "CHECK_WARNING", false)
+		local passed = waitForResult()
+		logTest(testNum, "no warning when stationary", passed)
+		assert(passed, "no warning when stationary")
+		testNum = testNum + 1
+
+		local correctCFrame = playerCar:GetPivot()
+		local wrongCFrame = correctCFrame * CFrame.Angles(0, math.pi, 0)
+
+		-- Test 3: Warning visible when moving in the wrong direction
+		driveAndCheck(wrongCFrame, 1, true, true, "warning visible when facing/moving wrong direction")
+
+		-- Test 4: No warning when reversing in the correct direction (special case - uses DRIVE_REVERSE)
+		playerCar:PivotTo(wrongCFrame)
+		task.wait(0.5)
+		testRemote:FireClient(player, "DRIVE_REVERSE")
+		waitForResult()
+		task.wait(1.5)
+		testRemote:FireClient(player, "CHECK_WARNING", false)
+		local test4Passed = waitForResult()
+		logTest(testNum, "no warning when facing wrong but moving correct", test4Passed)
+		assert(test4Passed, "no warning when facing wrong but moving correct")
+		testNum = testNum + 1
+		testRemote:FireClient(player, "STOP_DRIVING")
+		waitForResult()
+
+		-- Test 5: No warning when moving in the correct direction
+		driveAndCheck(correctCFrame, 1, false, false, "no warning when facing/moving correct direction")
+
+		-- Get checkpoint indices for early/mid/late positions
+		local n = #checkpoints
+		local testIndices = {math.ceil(n * 0.25), math.ceil(n * 0.5), math.ceil(n * 0.75)}
+
+		-- Tests 6-11: Checkpoint direction tests at early/mid/late positions
+		local positionLabels = {"early", "mid", "late"}
+		for i, idx in ipairs(testIndices) do
+			local checkpoint = checkpoints[idx]
+			if not checkpoint then continue end
+
+			local posLabel = positionLabels[i] or "checkpoint"
+			local cpPosition = checkpoint.Position + Vector3.new(0, 8, 0) -- Higher to avoid ground collision
+			local trackDir = (checkpoint.CFrame.LookVector * HORIZONTAL).Unit
+			local cpCorrectCFrame = CFrame.lookAt(cpPosition, cpPosition + trackDir)
+			local cpWrongCFrame = cpCorrectCFrame * CFrame.Angles(0, math.pi, 0)
+
+			-- Drive along track in correct direction
+			driveAndCheck(cpCorrectCFrame, idx, false, false, posLabel .. " checkpoint - correct direction", 8)
+			-- Drive along track in wrong direction (car faces backwards, moves backwards along track)
+			driveAndCheck(cpWrongCFrame, idx, true, true, posLabel .. " checkpoint - wrong direction", 8)
+		end
+
+		-- Test 12: Full lap wrong direction at high speed - verify warning stays visible
+		local allWaypoints = {}
+		for i = 1, #tracedPath do
+			local sample = tracedPath[i]
+			table.insert(allWaypoints, {
+				position = sample.position,
+				tangent = -sample.tangent -- Reversed for wrong direction
+			})
+		end
+
+		-- Start at checkpoint 1, facing wrong direction
+		local startCheckpoint = checkpoints[1]
+		local startPos = startCheckpoint.Position + Vector3.new(0, 8, 0)
+		local startDir = -(startCheckpoint.CFrame.LookVector * HORIZONTAL).Unit
+		local startCFrame = CFrame.lookAt(startPos, startPos + startDir)
+
+		playerCar:PivotTo(startCFrame)
+		task.wait(0.5)
+
+		-- Calculate approximate lap distance and time needed
+		local totalDistance = 0
+		for i = 1, #allWaypoints - 1 do
+			local p1 = allWaypoints[i].position
+			local p2 = allWaypoints[i + 1].position
+			totalDistance = totalDistance + (p2 - p1).Magnitude
+		end
+		-- Add distance from last to first (loop closure)
+		totalDistance = totalDistance + (allWaypoints[1].position - allWaypoints[#allWaypoints].position).Magnitude
+
+		local speed = 100
+		local lapTime = math.ceil(totalDistance / speed) + 5 -- Add buffer time
+
+		-- Drive full lap at high speed, check warning multiple times
+		testRemote:FireClient(player, "DRIVE_ALONG_TRACK", {
+			waypoints = allWaypoints,
+			duration = lapTime,
+			speed = speed,
+			turnSpeed = 20 -- Fast turning for high speed
+		})
+		waitForResult()
+
+		-- Check warning visibility during the lap (every ~20% of lap)
+		local checkInterval = math.max(2, math.floor(lapTime / 6))
+		local warningChecks = 0
+		local warningVisible = 0
+		for checkNum = 1, 5 do
+			task.wait(checkInterval)
+			testRemote:FireClient(player, "CHECK_WARNING", true)
+			local checkPassed = waitForResult()
+			warningChecks = warningChecks + 1
+			if checkPassed then warningVisible = warningVisible + 1 end
+
+			-- Check if car is near start (completed lap)
+			local carPos = playerCar:GetPivot().Position
+			local distFromStart = ((carPos - startPos) * HORIZONTAL).Magnitude
+			if checkNum >= 3 and distFromStart < 50 then
+				break
+			end
+		end
+
+		testRemote:FireClient(player, "STOP_DRIVING")
+		waitForResult()
+
+		local fullLapPassed = warningVisible >= math.max(1, warningChecks - 1) -- Allow 1 miss
+		logTest(testNum, string.format("full lap wrong direction (%d/%d checks passed)", warningVisible, warningChecks), fullLapPassed)
+		assert(fullLapPassed, "full lap wrong direction")
+	end
+
+	local success, err = pcall(runTests)
+	if not success then
+		warn("Test error: " .. tostring(err))
+	end
+
+	testRemote:FireClient(player, "TESTS_COMPLETE")
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(_logService)
+	local Players = game:GetService("Players")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local RunService = game:GetService("RunService")
+
+	local player = Players.LocalPlayer
+	local playerGui = player:WaitForChild("PlayerGui")
+
+	local testRemote = ReplicatedStorage:WaitForChild(testRemoteName, 5) :: RemoteEvent
+
+	local driveConnection = nil
+
+	-- Search PlayerGui for "WRONG DIRECTION" text
+	local function findWarningElement()
+		for _, desc in playerGui:GetDescendants() do
+			if desc:IsA("GuiObject") then
+				local ok, text = pcall(function() return desc.Text end)
+				if ok and text then
+					local upper = string.upper(text)
+					if string.find(upper, "WRONG") and string.find(upper, "DIRECTION") then
+						return desc
+					end
+				end
+			end
+		end
+		return nil
+	end
+
+	-- Check element and ancestors are visible
+	local function isWarningVisible(element)
+		if not element or not element.Parent then return false end
+		local current = element
+		while current and current ~= playerGui do
+			if current:IsA("GuiObject") and current.Visible == false then return false end
+			current = current.Parent
+		end
+		return element.Visible == true
+	end
+
+	local function getSeatAndCar()
+		local character = player.Character
+		if not character then return nil, nil end
+		local humanoid = character:FindFirstChildOfClass("Humanoid")
+		if not humanoid or not humanoid.SeatPart or not humanoid.SeatPart:IsA("VehicleSeat") then
+			return nil, nil
+		end
+		local seat = humanoid.SeatPart
+		local car = seat:FindFirstAncestorWhichIsA("Model")
+		if not car or not car.PrimaryPart then return nil, nil end
+		return seat, car
+	end
+
+	local HORIZONTAL = Vector3.new(1, 0, 1)
+
+	-- Helper: find nearest waypoint and return its tangent
+	local function findNearestWaypointTangent(car: Model, waypoints: {{position: Vector3, tangent: Vector3}}): Vector3
+		local carPos = car:GetPivot().Position * HORIZONTAL
+		local nearestIdx = 1
+		local nearestDist = math.huge
+		for i, wp in ipairs(waypoints) do
+			local wpPos = wp.position :: Vector3
+			local dist = ((wpPos * HORIZONTAL) - carPos).Magnitude
+			if dist < nearestDist then
+				nearestDist = dist
+				nearestIdx = i
+			end
+		end
+		return waypoints[nearestIdx].tangent :: Vector3
+	end
+
+	-- Helper: steer car to face a direction
+	local function steerTowardDirection(car: Model, direction: Vector3, turnSpeed: number, dt: number)
+		local currentCFrame = car:GetPivot()
+		local targetCFrame = CFrame.lookAt(currentCFrame.Position, currentCFrame.Position + direction)
+		local newCFrame = currentCFrame:Lerp(targetCFrame, math.min(1, turnSpeed * dt))
+		car:PivotTo(newCFrame)
+	end
+
+	local function handleCommand(command, data)
+		if command == "CHECK_WARNING" then
+			local expectVisible = data
+			local element = findWarningElement()
+			if not element then
+				-- No element: pass if expecting hidden, fail if expecting visible
+				testRemote:FireServer("CHECK_DONE", not expectVisible)
+				return not expectVisible
+			end
+			local visible = isWarningVisible(element)
+			local passed = (visible == expectVisible)
+			testRemote:FireServer("CHECK_DONE", passed)
+			return passed
+
+		elseif command == "DRIVE_REVERSE" then
+			local seat, car = getSeatAndCar()
+			if not seat or not car then
+				testRemote:FireServer("CHECK_DONE", false)
+				return false
+			end
+
+			if driveConnection then driveConnection:Disconnect() end
+			driveConnection = RunService.Heartbeat:Connect(function()
+				car.PrimaryPart.AssemblyLinearVelocity = -seat.CFrame.LookVector * 25
+			end)
+			testRemote:FireServer("CHECK_DONE", true)
+			return true
+
+		elseif command == "DRIVE_ALONG_TRACK" then
+			local waypoints = data.waypoints
+			local duration = data.duration or 3
+			local speed = data.speed or 30
+			local turnSpeed = data.turnSpeed or 8
+
+			if driveConnection then driveConnection:Disconnect() end
+			local _, car = getSeatAndCar()
+			if not car then
+				testRemote:FireServer("CHECK_DONE", false)
+				return false
+			end
+
+			local startTime = os.clock()
+
+			driveConnection = RunService.Heartbeat:Connect(function(dt)
+				if os.clock() - startTime >= duration then
+					return
+				end
+
+				local tangent = findNearestWaypointTangent(car, waypoints)
+				steerTowardDirection(car, tangent, turnSpeed, dt)
+				car.PrimaryPart.AssemblyLinearVelocity = tangent * speed
+			end)
+
+			testRemote:FireServer("CHECK_DONE", true)
+			return true
+
+		elseif command == "STOP_DRIVING" then
+			if driveConnection then
+				driveConnection:Disconnect()
+				driveConnection = nil
+			end
+			local seat, car = getSeatAndCar()
+			if seat then
+				seat.ThrottleFloat = 0
+				seat.SteerFloat = 0
+			end
+			if car and car.PrimaryPart then car.PrimaryPart.AssemblyLinearVelocity = Vector3.zero end
+			testRemote:FireServer("CHECK_DONE", true)
+			return true
+
+		elseif command == "TESTS_COMPLETE" then
+			return true
+		end
+		return false
+	end
+
+	testRemote:FireServer("CLIENT_READY")
+
+	while true do
+		local command, data = testRemote.OnClientEvent:Wait()
+		handleCommand(command, data)
+		if command == "TESTS_COMPLETE" then break end
+	end
+end)
+
+return eval

--- a/Evals/117_fnf_enter_game_ui_menu.lua
+++ b/Evals/117_fnf_enter_game_ui_menu.lua
@@ -1,0 +1,443 @@
+--!strict
+local LoadedCode = game:FindFirstChild("LoadedCode")
+
+if LoadedCode:FindFirstChild("EvalUtils") then
+	local types = require(LoadedCode.EvalUtils.types)
+	local utils_runs = require(LoadedCode.EvalUtils.utils_runs)
+	local utils_he = require(LoadedCode.EvalUtils.utils_he)
+	local lib = require(LoadedCode.EvalUtils.lib)
+else
+	local types = require(game.LoadedCode.types)
+end
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "117_fnf_enter_game_ui_menu",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[1. Before entering the game, display a menu with:
+   - "Play" button that leads to the scene.
+   - "Freeplay" button to choose songs (only placeholder).
+   - "Exit" button that closes the menu.
+2. Add a logo that says "Friday Night Funkin' Roblox"]],
+				
+			}
+		}
+	},
+	place = "baseplate.rbxl",
+	expected_tool_calls = { "execute_luau", "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+
+eval.reference = function()
+	local StarterGui = game:GetService("StarterGui")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local ServerScriptService = game:GetService("ServerScriptService")
+
+	-- Create RemoteEvents for button click communication
+	local menuEventsFolder = Instance.new("Folder")
+	menuEventsFolder.Name = "MenuEvents"
+	menuEventsFolder.Parent = ReplicatedStorage
+
+	local playClickedEvent = Instance.new("RemoteEvent")
+	playClickedEvent.Name = "PlayClicked"
+	playClickedEvent.Parent = menuEventsFolder
+
+	local freeplayClickedEvent = Instance.new("RemoteEvent")
+	freeplayClickedEvent.Name = "FreeplayClicked"
+	freeplayClickedEvent.Parent = menuEventsFolder
+
+	local exitClickedEvent = Instance.new("RemoteEvent")
+	exitClickedEvent.Name = "ExitClicked"
+	exitClickedEvent.Parent = menuEventsFolder
+
+	-- Main Menu ScreenGui
+	local menuGui = Instance.new("ScreenGui")
+	menuGui.Name = "MainMenu"
+	menuGui.ResetOnSpawn = false
+	menuGui.IgnoreGuiInset = true
+	menuGui.Parent = StarterGui
+
+	-- Background frame to cover screen
+	local background = Instance.new("Frame")
+	background.Name = "Background"
+	background.Size = UDim2.new(1, 0, 1, 0)
+	background.Position = UDim2.new(0, 0, 0, 0)
+	background.BackgroundColor3 = Color3.fromRGB(20, 20, 30)
+	background.BorderSizePixel = 0
+	background.Parent = menuGui
+
+	-- Logo logic here
+	local logo = Instance.new("TextLabel")
+	logo.Name = "Logo"
+	logo.Size = UDim2.new(0, 600, 0, 80)
+	logo.Position = UDim2.new(0.5, -300, 0.15, 0)
+	logo.BackgroundTransparency = 1
+	logo.Text = "Friday Night Funkin' Roblox"
+	logo.TextColor3 = Color3.fromRGB(255, 100, 200)
+	logo.TextSize = 48
+	logo.Font = Enum.Font.GothamBold
+	logo.Parent = background
+
+	-- Menu container here
+	local menuFrame = Instance.new("Frame")
+	menuFrame.Name = "MenuFrame"
+	menuFrame.Size = UDim2.new(0, 300, 0, 250)
+	menuFrame.Position = UDim2.new(0.5, -150, 0.4, 0)
+	menuFrame.BackgroundColor3 = Color3.fromRGB(40, 40, 60)
+	menuFrame.BorderSizePixel = 0
+	menuFrame.Parent = background
+
+	local uiCorner = Instance.new("UICorner")
+	uiCorner.CornerRadius = UDim.new(0, 10)
+	uiCorner.Parent = menuFrame
+
+	-- Play Button logic here
+	local playButton = Instance.new("TextButton")
+	playButton.Name = "PlayButton"
+	playButton.Size = UDim2.new(0, 200, 0, 50)
+	playButton.Position = UDim2.new(0.5, -100, 0.1, 0)
+	playButton.BackgroundColor3 = Color3.fromRGB(50, 200, 100)
+	playButton.Text = "Play"
+	playButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+	playButton.TextSize = 24
+	playButton.Font = Enum.Font.GothamBold
+	playButton.Parent = menuFrame
+
+	local playCorner = Instance.new("UICorner")
+	playCorner.CornerRadius = UDim.new(0, 8)
+	playCorner.Parent = playButton
+
+	-- Freeplay Button logic here
+	local freeplayButton = Instance.new("TextButton")
+	freeplayButton.Name = "FreeplayButton"
+	freeplayButton.Size = UDim2.new(0, 200, 0, 50)
+	freeplayButton.Position = UDim2.new(0.5, -100, 0.4, 0)
+	freeplayButton.BackgroundColor3 = Color3.fromRGB(100, 100, 200)
+	freeplayButton.Text = "Freeplay"
+	freeplayButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+	freeplayButton.TextSize = 24
+	freeplayButton.Font = Enum.Font.GothamBold
+	freeplayButton.Parent = menuFrame
+
+	local freeplayCorner = Instance.new("UICorner")
+	freeplayCorner.CornerRadius = UDim.new(0, 8)
+	freeplayCorner.Parent = freeplayButton
+
+	-- Exit Button
+	local exitButton = Instance.new("TextButton")
+	exitButton.Name = "ExitButton"
+	exitButton.Size = UDim2.new(0, 200, 0, 50)
+	exitButton.Position = UDim2.new(0.5, -100, 0.7, 0)
+	exitButton.BackgroundColor3 = Color3.fromRGB(200, 80, 80)
+	exitButton.Text = "Exit"
+	exitButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+	exitButton.TextSize = 24
+	exitButton.Font = Enum.Font.GothamBold
+	exitButton.Parent = menuFrame
+
+	local exitCorner = Instance.new("UICorner")
+	exitCorner.CornerRadius = UDim.new(0, 8)
+	exitCorner.Parent = exitButton
+
+	-- Server script to handle menu events
+	local serverScript = Instance.new("Script")
+	serverScript.Name = "MenuServerHandler"
+	serverScript.Source = [[
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Players = game:GetService("Players")
+
+local menuEventsFolder = ReplicatedStorage:WaitForChild("MenuEvents")
+local playClickedEvent = menuEventsFolder:WaitForChild("PlayClicked")
+local freeplayClickedEvent = menuEventsFolder:WaitForChild("FreeplayClicked")
+local exitClickedEvent = menuEventsFolder:WaitForChild("ExitClicked")
+
+playClickedEvent.OnServerEvent:Connect(function(player)
+	-- Play button was clicked - player enters the scene
+	print(player.Name .. " clicked Play")
+end)
+
+freeplayClickedEvent.OnServerEvent:Connect(function(player)
+	-- Freeplay button was clicked currently as a placeholder, does nothing
+	print(player.Name .. " clicked Freeplay (placeholder)")
+end)
+
+exitClickedEvent.OnServerEvent:Connect(function(player)
+	-- Exit button was clicked  close menu and exit game
+	print(player.Name .. " clicked Exit")
+	-- Kick the player to exit the game
+	player:Kick("You have exited the game.")
+end)
+]]
+	serverScript.Parent = ServerScriptService
+
+	-- Client script to handle button clicks
+	local StarterPlayerScripts = game:GetService("StarterPlayer"):WaitForChild("StarterPlayerScripts")
+
+	local menuScript = Instance.new("LocalScript")
+	menuScript.Name = "MenuHandler"
+	menuScript.Source = [[
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local player = Players.LocalPlayer
+local playerGui = player:WaitForChild("PlayerGui")
+
+-- Wait for menu events
+local menuEventsFolder = ReplicatedStorage:WaitForChild("MenuEvents")
+local playClickedEvent = menuEventsFolder:WaitForChild("PlayClicked")
+local freeplayClickedEvent = menuEventsFolder:WaitForChild("FreeplayClicked")
+local exitClickedEvent = menuEventsFolder:WaitForChild("ExitClicked")
+
+-- Helper function to find button by text
+local function findButtonByText(parent, text)
+	for _, child in parent:GetDescendants() do
+		if child:IsA("TextButton") and string.lower(child.Text) == string.lower(text) then
+			return child
+		end
+	end
+	return nil
+end
+
+-- Helper function to find ScreenGui that is the main menu
+local function findMainMenuGui()
+	for _, gui in playerGui:GetChildren() do
+		if gui:IsA("ScreenGui") then
+			local hasPlay = findButtonByText(gui, "Play")
+			local hasFreeplay = findButtonByText(gui, "Freeplay")
+			local hasExit = findButtonByText(gui, "Exit")
+			if hasPlay and hasFreeplay and hasExit then
+				return gui
+			end
+		end
+	end
+	return nil
+end
+
+local mainMenu = findMainMenuGui()
+if not mainMenu then
+	task.wait(1)
+	mainMenu = findMainMenuGui()
+end
+
+if mainMenu then
+	local playButton = findButtonByText(mainMenu, "Play")
+	local freeplayButton = findButtonByText(mainMenu, "Freeplay")
+	local exitButton = findButtonByText(mainMenu, "Exit")
+
+	if playButton then
+		playButton.MouseButton1Click:Connect(function()
+			mainMenu.Enabled = false
+			playClickedEvent:FireServer()
+		end)
+	end
+
+	if freeplayButton then
+		freeplayButton.MouseButton1Click:Connect(function()
+			-- Placeholder: does nothing to menu state
+			freeplayClickedEvent:FireServer()
+		end)
+	end
+
+	if exitButton then
+		exitButton.MouseButton1Click:Connect(function()
+			-- Exit directly without showing scene (menu stays visible until kick)
+			exitClickedEvent:FireServer()
+		end)
+	end
+end
+]]
+	menuScript.Parent = StarterPlayerScripts
+end
+
+eval.check_scene = function()
+	local StarterGui = game:GetService("StarterGui")
+	local StarterPlayer = game:GetService("StarterPlayer")
+
+	-- Helper function to find a TextLabel containing specific text (case-insensitive partial match)
+	local function findTextLabelWithText(parent, searchText)
+		for _, descendant in parent:GetDescendants() do
+			if descendant:IsA("TextLabel") then
+				if string.find(string.lower(descendant.Text), string.lower(searchText)) then
+					return descendant
+				end
+			end
+		end
+		return nil
+	end
+
+	-- Helper function to find a TextButton with specific text (case-insensitive)
+	local function findButtonByText(parent, text)
+		for _, descendant in parent:GetDescendants() do
+			if descendant:IsA("TextButton") and string.lower(descendant.Text) == string.lower(text) then
+				return descendant
+			end
+		end
+		return nil
+	end
+
+	-- Helper function to find a ScreenGui that appears to be a main menu
+	local function findMainMenuScreenGui()
+		for _, gui in StarterGui:GetChildren() do
+			if gui:IsA("ScreenGui") then
+				local hasPlay = findButtonByText(gui, "Play") ~= nil
+				local hasFreeplay = findButtonByText(gui, "Freeplay") ~= nil
+				local hasExit = findButtonByText(gui, "Exit") ~= nil
+				if hasPlay and hasFreeplay and hasExit then
+					return gui
+				end
+			end
+		end
+		return nil
+	end
+
+	-- Test 1: A ScreenGui exists in StarterGui that functions as a main menu
+	local mainMenuGui = findMainMenuScreenGui()
+	assert(mainMenuGui, "No ScreenGui found in StarterGui containing Play, Freeplay, and Exit buttons")
+
+	-- Test 2: Logo exists with correct text containing "Friday Night Funkin'" and "Roblox"
+	local logoFNF = findTextLabelWithText(mainMenuGui, "Friday Night Funkin")
+	assert(logoFNF, "No TextLabel found containing 'Friday Night Funkin' text")
+	local logoRoblox = findTextLabelWithText(mainMenuGui, "Roblox")
+	assert(logoRoblox, "No TextLabel found containing 'Roblox' text")
+
+	-- Test 3: Play button exists and is a TextButton
+	local playButton = findButtonByText(mainMenuGui, "Play")
+	assert(playButton, "No TextButton with 'Play' text found in menu")
+	assert(playButton:IsA("TextButton"), "Play element is not a TextButton")
+
+	-- Test 4: Freeplay button exists and is a TextButton
+	local freeplayButton = findButtonByText(mainMenuGui, "Freeplay")
+	assert(freeplayButton, "No TextButton with 'Freeplay' text found in menu")
+	assert(freeplayButton:IsA("TextButton"), "Freeplay element is not a TextButton")
+
+	-- Test 5: Exit button exists and is a TextButton
+	local exitButton = findButtonByText(mainMenuGui, "Exit")
+	assert(exitButton, "No TextButton with 'Exit' text found in menu")
+	assert(exitButton:IsA("TextButton"), "Exit element is not a TextButton")
+
+	-- Test 6: There should be a LocalScript somewhere to handle menu interactions
+	local starterPlayerScripts = StarterPlayer:FindFirstChild("StarterPlayerScripts")
+	assert(starterPlayerScripts, "StarterPlayerScripts not found")
+
+	local foundLocalScript = false
+	for _, child in starterPlayerScripts:GetChildren() do
+		if child:IsA("LocalScript") then
+			foundLocalScript = true
+			break
+		end
+	end
+	assert(foundLocalScript, "No LocalScript found in StarterPlayerScripts to handle menu interactions")
+end
+
+-- deprecated not used anymore
+eval.check_game = function()
+end
+
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	-- Server check verifies the runtime behavior
+	-- We don't check for specific RemoteEvent names as that's an implementation detail
+	-- The important thing is that the button functionality works which is tested via clientChecks
+	-- and that the server can handle exit requests
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+	local Players = game:GetService("Players")
+	local player = Players.LocalPlayer
+	local playerGui = player:WaitForChild("PlayerGui", 10)
+
+	-- Helper function to find a TextButton with specific text 
+	local function findButtonByText(parent, text)
+		for _, descendant in parent:GetDescendants() do
+			if descendant:IsA("TextButton") and string.lower(descendant.Text) == string.lower(text) then
+				return descendant
+			end
+		end
+		return nil
+	end
+
+	-- Helper function to find the main menu ScreenGui
+	local function findMainMenuScreenGui()
+		for _, gui in playerGui:GetChildren() do
+			if gui:IsA("ScreenGui") then
+				-- instead of searching by some specific names, we simply findButtons which have
+				-- this string in their name
+				local hasPlay = findButtonByText(gui, "Play") ~= nil
+				local hasFreeplay = findButtonByText(gui, "Freeplay") ~= nil
+				local hasExit = findButtonByText(gui, "Exit") ~= nil
+				if hasPlay and hasFreeplay and hasExit then
+					return gui
+				end
+			end
+		end
+		return nil
+	end
+
+	task.wait(1)
+
+	-- Test 1: Main menu is visible when player joins
+	local mainMenu = findMainMenuScreenGui()
+	assert(mainMenu, "Main menu ScreenGui not found in PlayerGui")
+	assert(mainMenu.Enabled == true, "Main menu should be enabled (visible) when player joins")
+
+	-- Test 2: All buttons exist and are interactable
+	local playButton = findButtonByText(mainMenu, "Play")
+	local freeplayButton = findButtonByText(mainMenu, "Freeplay")
+	local exitButton = findButtonByText(mainMenu, "Exit")
+
+	assert(playButton, "Play button not found in menu")
+	assert(freeplayButton, "Freeplay button not found in menu")
+	assert(exitButton, "Exit button not found in menu")
+
+	-- Runtime Test 3: Buttons are visible and active (can receive clicks)
+	assert(playButton.Visible == true, "Play button should be visible")
+	assert(freeplayButton.Visible == true, "Freeplay button should be visible")
+	assert(exitButton.Visible == true, "Exit button should be visible")
+
+	assert(playButton.Active == true, "Play button should be active/interactable")
+	assert(freeplayButton.Active == true, "Freeplay button should be active/interactable")
+	assert(exitButton.Active == true, "Exit button should be active/interactable")
+
+	-- Runtime Test 4: Verify menu handler script is running by checking PlayerScripts
+	local playerScripts = player:FindFirstChild("PlayerScripts")
+	assert(playerScripts, "PlayerScripts not found")
+	
+	local foundMenuHandler = false
+	for _, script in playerScripts:GetDescendants() do
+		if script:IsA("LocalScript") then
+			foundMenuHandler = true
+			break
+		end
+	end
+	assert(foundMenuHandler, "No LocalScript found running in PlayerScripts to handle menu interactions")
+end)
+
+return eval

--- a/Evals/117_fnf_enter_game_ui_menu.lua
+++ b/Evals/117_fnf_enter_game_ui_menu.lua
@@ -28,9 +28,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "baseplate.rbxl",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/118_weapon_spawn_and_pickup.lua
+++ b/Evals/118_weapon_spawn_and_pickup.lua
@@ -1,0 +1,614 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+if LoadedCode:FindFirstChild("EvalUtils") then
+	local types = require(LoadedCode.EvalUtils.types)
+	local utils_runs = require(LoadedCode.EvalUtils.utils_runs)
+
+	local lib = require(LoadedCode.EvalUtils.lib)
+else
+	local types = require(game.LoadedCode.types)
+end
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "118_weapon_spawn_and_pickup",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make the items pistol, axe, and knife spawn in various locations on the map, and ensure that the player can only pick up one of each.]],
+				
+			},
+		},
+	},
+	place = "baseplate.rbxl",
+	expected_tool_calls = { "execute_luau", "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	},
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+	-- Create item templates in ServerStorage
+	local ServerStorage = game:GetService("ServerStorage")
+
+	local templatesFolder = ServerStorage:FindFirstChild("ItemTemplates")
+	if templatesFolder then
+		templatesFolder:Destroy()
+	end
+	templatesFolder = Instance.new("Folder")
+	templatesFolder.Name = "ItemTemplates"
+	templatesFolder.Parent = ServerStorage
+
+	local function makeToolTemplate(toolName: string, color: Color3)
+		local tool = Instance.new("Tool")
+		tool.Name = toolName
+		tool.CanBeDropped = false
+
+		local handle = Instance.new("Part")
+		handle.Name = "Handle"
+		handle.Size = Vector3.new(1, 1, 2)
+		handle.Anchored = false
+		handle.CanCollide = true
+		handle.Color = color
+		handle.Parent = tool
+
+		tool.Parent = templatesFolder
+	end
+
+	makeToolTemplate("pistol", Color3.fromRGB(40, 40, 40))
+	makeToolTemplate("axe", Color3.fromRGB(120, 60, 20))
+	makeToolTemplate("knife", Color3.fromRGB(180, 180, 180))
+end
+
+eval.reference = function()
+	local ServerScriptService = game:GetService("ServerScriptService")
+	local scriptName = "ItemSpawner_Pilot015"
+
+	local existing = ServerScriptService:FindFirstChild(scriptName)
+	if existing then
+		existing:Destroy()
+	end
+
+	local spawnerScript = Instance.new("Script")
+	spawnerScript.Name = scriptName
+	spawnerScript.Source = [[
+		local Players = game:GetService("Players")
+		local ServerStorage = game:GetService("ServerStorage")
+		local Workspace = game:GetService("Workspace")
+
+		local templatesFolder = ServerStorage:WaitForChild("ItemTemplates")
+
+		local RESPAWN_DELAY = 3
+
+		local SPAWN_CONFIG = {
+			{Item = "pistol", Pos = Vector3.new(10, 1, 15)},
+			{Item = "pistol", Pos = Vector3.new(120, 1, 40)},
+			{Item = "pistol", Pos = Vector3.new(-140, 1, -60)},
+
+			{Item = "axe",    Pos = Vector3.new(60, 1, 180)},
+			{Item = "axe",    Pos = Vector3.new(-80, 1, 140)},
+			{Item = "axe",    Pos = Vector3.new(170, 1, -120)},
+
+			{Item = "knife",  Pos = Vector3.new(-200, 1, 20)},
+			{Item = "knife",  Pos = Vector3.new(30, 1, -220)},
+			{Item = "knife",  Pos = Vector3.new(210, 1, 110)},
+		}
+
+		local spawnFolder = Workspace:FindFirstChild("SpawnedItems_Pilot015")
+		if spawnFolder then
+			spawnFolder:Destroy()
+		end
+		spawnFolder = Instance.new("Folder")
+		spawnFolder.Name = "SpawnedItems_Pilot015"
+		spawnFolder.Parent = Workspace
+
+		local function countTools(container: Instance?, itemName: string): number
+			if not container then
+				return 0
+			end
+			local n = 0
+			for _, ch in ipairs(container:GetChildren()) do
+				if ch:IsA("Tool") and ch.Name == itemName then
+					n += 1
+				end
+			end
+			return n
+		end
+
+		local function playerHasItem(player: Player, itemName: string): boolean
+			local backpack = player:FindFirstChild("Backpack")
+			local character = player.Character
+
+			if countTools(backpack, itemName) > 0 then
+				return true
+			end
+			if character and countTools(character, itemName) > 0 then
+				return true
+			end
+
+			return false
+		end
+
+		local function spawnPickupOnce(itemName: string, position: Vector3)
+			local templateTool = templatesFolder:FindFirstChild(itemName)
+			if not templateTool or not templateTool:IsA("Tool") then
+				return
+			end
+
+			local handleTemplate = templateTool:FindFirstChild("Handle")
+			if not handleTemplate or not handleTemplate:IsA("BasePart") then
+				return
+			end
+
+			local visualModel = Instance.new("Model")
+			visualModel.Name = itemName
+
+			local visualPart = handleTemplate:Clone()
+			visualPart.Name = "PickupPart"
+			visualPart.CFrame = CFrame.new(position) * CFrame.Angles(0, math.rad(math.random(0, 360)), 0)
+			visualPart.Anchored = true
+			visualPart.CanCollide = false
+			visualPart.Parent = visualModel
+
+			visualModel.Parent = spawnFolder
+
+			local debounce = false
+			local connection: RBXScriptConnection? = nil
+
+			connection = visualPart.Touched:Connect(function(hit)
+				if debounce then
+					return
+				end
+
+				local character = hit.Parent
+				local player = character and Players:GetPlayerFromCharacter(character)
+				if not player then
+					return
+				end
+
+				-- Ensure backpack exists
+				local backpack = player:FindFirstChild("Backpack")
+				if not backpack then
+					backpack = player:WaitForChild("Backpack", 5)
+				end
+				if not backpack then
+					return
+				end
+
+				-- Enforce "only pick up one of each"
+				if playerHasItem(player, itemName) then
+					return
+				end
+
+				debounce = true
+
+				local realTool = templateTool:Clone()
+				realTool.Parent = backpack
+
+				if connection then
+					connection:Disconnect()
+					connection = nil
+				end
+				visualModel:Destroy()
+			end)
+		end
+
+		for _, config in ipairs(SPAWN_CONFIG) do
+			task.spawn(function()
+				spawnPickupOnce(config.Item, config.Pos)
+			end)
+		end
+	]]
+	spawnerScript.Parent = ServerScriptService
+	spawnerScript.Enabled = true
+end
+
+eval.check_scene = function() end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	local Workspace = game:GetService("Workspace")
+	local ITEM_NAMES = { "pistol", "axe", "knife" }
+	local MIN_DIST = 10
+
+	local function isWorldPickupCandidate(inst: Instance, itemName: string): boolean
+		if not inst:IsDescendantOf(Workspace) then
+			return false
+		end
+
+		if inst:IsA("Tool") and string.lower(inst.Name):find(itemName, 1, true) then
+			return true
+		end
+
+		if (inst:IsA("Model") or inst:IsA("BasePart")) and string.lower(inst.Name):find(itemName, 1, true) then
+			return true
+		end
+
+		return false
+	end
+
+	local function getWorldPickupPositions(itemName: string): { Vector3 }
+		local positions: { Vector3 } = {}
+		for _, inst in ipairs(Workspace:GetDescendants()) do
+			if isWorldPickupCandidate(inst, itemName) then
+				if inst:IsA("Tool") then
+					local handle = inst:FindFirstChild("Handle")
+					if handle and handle:IsA("BasePart") then
+						table.insert(positions, handle.Position)
+					end
+				elseif inst:IsA("BasePart") then
+					table.insert(positions, inst.Position)
+				elseif inst:IsA("Model") then
+					local pp = inst.PrimaryPart
+					if pp and pp:IsA("BasePart") then
+						table.insert(positions, pp.Position)
+					else
+						local cf, _ = inst:GetBoundingBox()
+						table.insert(positions, cf.Position)
+					end
+				end
+			end
+		end
+		return positions
+	end
+
+	local function hasMultipleDistinctPositions(positions: { Vector3 }): boolean
+		if #positions < 2 then
+			return false
+		end
+		for i = 1, #positions do
+			for j = i + 1, #positions do
+				if (positions[i] - positions[j]).Magnitude >= MIN_DIST then
+					return true
+				end
+			end
+		end
+		return false
+	end
+
+	-- Unit Test: Verify items spawn in various locations (>= 2 distinct positions)
+	local deadline = os.clock() + 10
+	local results: { [string]: { Vector3 } } = {}
+
+	while os.clock() < deadline do
+		local allOk = true
+		for _, itemName in ipairs(ITEM_NAMES) do
+			local pos = getWorldPickupPositions(itemName)
+			results[itemName] = pos
+			if not hasMultipleDistinctPositions(pos) then
+				allOk = false
+			end
+		end
+		if allOk then
+			break
+		end
+		task.wait(0.25)
+	end
+
+	for _, itemName in ipairs(ITEM_NAMES) do
+		local pos = results[itemName] or {}
+		assert(
+			hasMultipleDistinctPositions(pos),
+			("Expected '%s' to spawn in various locations (found %d pickup candidate(s), need >=2 distinct positions)."):format(
+				itemName,
+				#pos
+			)
+		)
+	end
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+	local Players = game:GetService("Players")
+	local Workspace = game:GetService("Workspace")
+
+	local localPlayer = Players.LocalPlayer
+	while not localPlayer do
+		localPlayer = Players.LocalPlayer
+		task.wait(0.1)
+	end
+
+	-- Inventory helpers
+	local function getBackpack(player: Player): Instance
+		local backpack = player:FindFirstChild("Backpack")
+		if backpack then
+			return backpack
+		end
+		backpack = player:WaitForChild("Backpack", 10)
+		assert(backpack, "Backpack not found for player")
+		return backpack
+	end
+
+	local function countToolsByName(container: Instance, toolName: string): number
+		local n = 0
+		for _, ch in ipairs(container:GetChildren()) do
+			if ch:IsA("Tool") and ch.Name == toolName then
+				n += 1
+			end
+		end
+		return n
+	end
+
+	local function playerToolCount(player: Player, toolName: string): number
+		local backpack = getBackpack(player)
+		local char = player.Character
+		local n = countToolsByName(backpack, toolName)
+		if char then
+			n += countToolsByName(char, toolName)
+		end
+		return n
+	end
+
+	local function waitForCharacter(player: Player): Model
+		local char = player.Character
+		if char then
+			return char
+		end
+		while not char do
+			char = player.Character
+			task.wait(0.1)
+		end
+		return char
+	end
+
+	local function getHRP(char: Model): BasePart
+		local hrp = char:WaitForChild("HumanoidRootPart")
+		return hrp :: BasePart
+	end
+
+	local function modelToPart(m: Model): BasePart?
+		if m.PrimaryPart and m.PrimaryPart:IsA("BasePart") then
+			return m.PrimaryPart
+		end
+
+		local best: BasePart? = nil
+		local bestVolume = -math.huge
+		for _, d in ipairs(m:GetDescendants()) do
+			if d:IsA("BasePart") then
+				local s = d.Size
+				local volume = s.X * s.Y * s.Z
+				if volume > bestVolume then
+					bestVolume = volume
+					best = d
+				end
+			end
+		end
+		return best
+	end
+
+	local function listPickupTargetsByName(itemName: string): { BasePart }
+		local targets: { BasePart } = {}
+		for _, inst in ipairs(Workspace:GetDescendants()) do
+			if inst:IsA("Tool") then
+				local lowerName = string.lower(inst.Name)
+				if lowerName == itemName or lowerName:find(itemName, 1, true) then
+					local handle = inst:FindFirstChild("Handle")
+					if handle and handle:IsA("BasePart") then
+						table.insert(targets, handle)
+					end
+				end
+			elseif inst:IsA("BasePart") then
+				local lowerName = string.lower(inst.Name)
+				if lowerName == itemName or lowerName:find(itemName, 1, true) then
+					table.insert(targets, inst)
+				end
+			elseif inst:IsA("Model") then
+				local lowerName = string.lower(inst.Name)
+				if lowerName == itemName or lowerName:find(itemName, 1, true) then
+					local part = modelToPart(inst)
+					if part then
+						table.insert(targets, part)
+					end
+				end
+			end
+		end
+		return targets
+	end
+
+	local function listPickupTargetsByPromptText(itemName: string): { BasePart }
+		local targets: { BasePart } = {}
+		for _, inst in ipairs(Workspace:GetDescendants()) do
+			if inst:IsA("ProximityPrompt") then
+				local obj = string.lower(inst.ObjectText or "")
+				local act = string.lower(inst.ActionText or "")
+				if obj:find(itemName, 1, true) or act:find(itemName, 1, true) then
+					local parent = inst.Parent
+					if parent and parent:IsA("BasePart") then
+						table.insert(targets, parent)
+					end
+				end
+			end
+		end
+		return targets
+	end
+
+	local function listAllPickupTargets(itemName: string): { BasePart }
+		local seen: { [Instance]: boolean } = {}
+		local out: { BasePart } = {}
+
+		for _, t in ipairs(listPickupTargetsByName(itemName)) do
+			if not seen[t] then
+				seen[t] = true
+				table.insert(out, t)
+			end
+		end
+		for _, t in ipairs(listPickupTargetsByPromptText(itemName)) do
+			if not seen[t] then
+				seen[t] = true
+				table.insert(out, t)
+			end
+		end
+
+		return out
+	end
+
+	local function pickTwoDistinctTargets(itemName: string): (BasePart?, BasePart?)
+		local targets = listAllPickupTargets(itemName)
+		if #targets < 2 then
+			return nil, nil
+		end
+
+		local bestA: BasePart? = nil
+		local bestB: BasePart? = nil
+		local bestDist = -1
+
+		for i = 1, #targets do
+			for j = i + 1, #targets do
+				local d = (targets[i].Position - targets[j].Position).Magnitude
+				if d > bestDist then
+					bestDist = d
+					bestA = targets[i]
+					bestB = targets[j]
+				end
+			end
+		end
+
+		return bestA, bestB
+	end
+
+	local function teleportNear(char: Model, target: BasePart)
+		local hrp = getHRP(char)
+		hrp.CFrame = target.CFrame + Vector3.new(0, 2, 0)
+	end
+
+	local function waitForToolCountDelta(player: Player, toolName: string, baseCount: number, expectedDelta: number, timeoutSeconds: number): boolean
+		local deadline = os.clock() + timeoutSeconds
+		while os.clock() < deadline do
+			local now = playerToolCount(player, toolName)
+			if (now - baseCount) >= expectedDelta then
+				return true
+			end
+			task.wait(0.1)
+		end
+		return false
+	end
+
+	-- ProximityPrompt best-effort activation (pattern used in other evals)
+	local function findPromptNearTarget(target: BasePart): ProximityPrompt?
+		local root: Instance = target
+		local modelAncestor = target:FindFirstAncestorOfClass("Model")
+		if modelAncestor then
+			root = modelAncestor
+		elseif target.Parent then
+			root = target.Parent
+		end
+
+		for _, d in ipairs(root:GetDescendants()) do
+			if d:IsA("ProximityPrompt") then
+				return d
+			end
+		end
+		return nil
+	end
+
+	local function tryActivatePrompt(prompt: ProximityPrompt)
+		pcall(function()
+			prompt:InputHoldBegin()
+		end)
+		task.wait((prompt.HoldDuration or 0) + 0.1)
+		pcall(function()
+			prompt:InputHoldEnd()
+		end)
+	end
+
+	local function tryAcquireByApproach(char: Model, itemName: string, target: BasePart, baseCount: number): boolean
+		teleportNear(char, target)
+
+		-- If a ProximityPrompt exists, try to activate it (best-effort).
+		local prompt = findPromptNearTarget(target)
+				
+		if prompt then
+			tryActivatePrompt(prompt)
+		end
+
+		-- Regardless of interaction mechanism, validate by outcome.
+		return waitForToolCountDelta(localPlayer, itemName, baseCount, 1, 6)
+	end
+
+	-- Execution Setup
+	local character = waitForCharacter(localPlayer)
+	local hrp = getHRP(character)
+	local originalCFrame = hrp.CFrame
+
+	-- Stage away from the map to reduce accidental pickups while discovering targets
+	hrp.CFrame = CFrame.new(0, 300, 0)
+	task.wait(0.75)
+
+	local ITEM_NAMES = { "pistol", "axe", "knife" }
+
+	-- Unit Test 1: Player can acquire each item once.
+	for _, itemName in ipairs(ITEM_NAMES) do
+		local t1, _t2 = pickTwoDistinctTargets(itemName)
+		assert(t1, ("Expected at least 2 pickup candidates for '%s' in the world (various locations)."):format(itemName))
+
+		local baseToolCount = playerToolCount(localPlayer, itemName)
+
+		local picked = false
+		for _ = 1, 3 do
+			if tryAcquireByApproach(character, itemName, t1 :: BasePart, baseToolCount) then
+				picked = true
+				break
+			end
+			task.wait(0.5)
+		end
+
+		assert(picked, ("Expected player to be able to acquire '%s' at least once by approaching a pickup."):format(itemName))
+
+		hrp.CFrame = CFrame.new(0, 300, 0)
+		task.wait(0.5)
+	end
+
+	-- Unit Test 2: One-of-each constraint (re-acquire does not increase count).
+	for _, itemName in ipairs(ITEM_NAMES) do
+		local t1, t2 = pickTwoDistinctTargets(itemName)
+		assert(t1 and t2, ("Expected at least 2 pickup candidates for '%s' to test duplicate acquisition."):format(itemName))
+
+		local baseCount = playerToolCount(localPlayer, itemName)
+		assert(baseCount >= 1, ("Expected to already have at least 1 '%s' before duplicate test."):format(itemName))
+
+		-- Best-effort attempt to acquire again at a different pickup location
+		pcall(function()
+			teleportNear(character, t2 :: BasePart)
+			local prompt = findPromptNearTarget(t2 :: BasePart)
+			if prompt then
+				tryActivatePrompt(prompt)
+			end
+		end)
+		task.wait(2)
+
+		local afterCount = playerToolCount(localPlayer, itemName)
+		assert(
+			afterCount == baseCount,
+			("Expected player NOT to acquire a second '%s' (count went from %d to %d)."):format(itemName, baseCount, afterCount)
+		)
+
+		hrp.CFrame = CFrame.new(0, 300, 0)
+		task.wait(0.5)
+	end
+
+	hrp.CFrame = originalCFrame
+end)
+
+return eval

--- a/Evals/118_weapon_spawn_and_pickup.lua
+++ b/Evals/118_weapon_spawn_and_pickup.lua
@@ -25,9 +25,6 @@ local eval: BaseEval = {
 		},
 	},
 	place = "baseplate.rbxl",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/119_lasertag_add_megablaster.lua
+++ b/Evals/119_lasertag_add_megablaster.lua
@@ -24,9 +24,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "laser_tag.rbxl",
-	expected_tool_calls = { "game_tree", "execute_luau" },
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/119_lasertag_add_megablaster.lua
+++ b/Evals/119_lasertag_add_megablaster.lua
@@ -1,0 +1,224 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+if LoadedCode:FindFirstChild("EvalUtils") then
+	local types = require(LoadedCode.EvalUtils.types)
+	local utils_runs = require(LoadedCode.EvalUtils.utils_runs)
+	local utils_he = require(LoadedCode.EvalUtils.utils_he)
+	local lib = require(LoadedCode.EvalUtils.lib)
+else
+	local types = require(game.LoadedCode.types)
+end
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "119_lasertag_add_megablaster",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Add a MegaBlaster that works in StarterPack.]],
+				
+			}
+		}
+	},
+	place = "laser_tag.rbxl",
+	expected_tool_calls = { "game_tree", "execute_luau" },
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+end
+
+eval.reference = function()
+	local StarterPack = game:GetService("StarterPack")
+
+	-- Find an existing blaster to use as template
+	local templateBlaster = StarterPack:FindFirstChild("Blaster") or StarterPack:FindFirstChild("AutoBlaster")
+	assert(templateBlaster, "No blaster found in StarterPack to use as template")
+
+	-- Clone the template
+	local megaBlaster = templateBlaster:Clone()
+	megaBlaster.Name = "MegaBlaster"
+
+	-- Make it "mega" by improving various attributes
+	megaBlaster:SetAttribute("damage", 50)
+	megaBlaster:SetAttribute("magazineSize", 50)
+	megaBlaster:SetAttribute("_ammo", 50)
+	megaBlaster:SetAttribute("rateOfFire", 600)
+	megaBlaster:SetAttribute("spread", 2)
+	megaBlaster:SetAttribute("range", 500)
+
+	megaBlaster.Parent = StarterPack
+end
+
+eval.check_scene = function()
+	local StarterPack = game:GetService("StarterPack")
+
+	-- Test 1: Tool named "MegaBlaster" exists in StarterPack
+	local megaBlaster = StarterPack:FindFirstChild("MegaBlaster")
+	assert(megaBlaster, "MegaBlaster tool not found in StarterPack")
+	assert(megaBlaster:IsA("Tool"), "MegaBlaster must be a Tool object")
+
+	-- Test 2: Tool has required Handle part
+	local handle = megaBlaster:FindFirstChild("Handle")
+	assert(handle, "MegaBlaster must have a Handle part")
+	assert(handle:IsA("BasePart"), "Handle must be a BasePart")
+
+	-- Test 3: Handle is not anchored (allows equipping)
+	assert(not handle.Anchored, "Handle must not be Anchored to allow proper equipping")
+
+	-- Test 4: Tool has basic weapon attributes required by Blaster system
+	local hasWeaponAttributes = false
+	local attributes = megaBlaster:GetAttributes()
+
+	-- Look for any of the key weapon attributes
+	if attributes.damage or attributes.magazineSize or attributes._ammo or attributes.fireMode then
+		hasWeaponAttributes = true
+	end
+
+	assert(hasWeaponAttributes, "MegaBlaster must have basic weapon attributes (damage, magazineSize, _ammo, or fireMode)")
+
+	-- Test 5: Verify "Mega" differentiation - MegaBlaster should be enhanced compared to AutoBlaster
+	local isMega = false
+	local megaAttributes = megaBlaster:GetAttributes()
+
+	-- Helper function to calculate DPS
+	local function calculateDPS(attrs)
+		local damage = attrs.damage
+		local rateOfFire = attrs.rateOfFire
+		local raysPerShot = attrs.raysPerShot
+		local magazineSize = attrs.magazineSize
+		local reloadTime = attrs.reloadTime
+
+		local shotsPerSecond = rateOfFire / 60
+		local damagePerShot = damage * raysPerShot
+
+		-- For infinite ammo, just return raw DPS
+		if not magazineSize or magazineSize == 0 then
+			return damagePerShot * shotsPerSecond
+		end
+
+		-- For weapons with magazine, calculate sustained DPS
+		local timeToEmptyMag = magazineSize / shotsPerSecond
+		local totalDamagePerCycle = damagePerShot * magazineSize
+		local sustainedDPS = totalDamagePerCycle / (timeToEmptyMag + reloadTime)
+
+		return sustainedDPS
+	end
+
+	-- Compare against AutoBlaster (should be in the scene as the best Blaster)
+	local comparisonBlaster = StarterPack:FindFirstChild("AutoBlaster") or StarterPack:FindFirstChild("Blaster")
+	assert(comparisonBlaster, "AutoBlaster or Blaster not found in the scene.")
+
+	local comparisonAttributes = comparisonBlaster:GetAttributes()
+
+	-- Calculate DPS (handles both finite and infinite ammo)
+	local megaDPS = calculateDPS(megaAttributes)
+	local comparisonDPS = calculateDPS(comparisonAttributes)
+
+	if megaDPS > comparisonDPS then
+		isMega = true
+	end
+
+	-- Individual stat improvements
+	local megaDamage = (megaAttributes.damage or 10) * (megaAttributes.raysPerShot or 1)
+	local comparisonDamage = (comparisonAttributes.damage or 10) * (comparisonAttributes.raysPerShot or 1)
+
+	if megaDamage > comparisonDamage then
+		isMega = true
+	end
+
+	-- Special range
+	if (megaAttributes.range or 1000) > (comparisonAttributes.range or 1000) then
+		isMega = true
+	end
+
+	-- More accuracy
+	if (megaAttributes.spread or 5) < (comparisonAttributes.spread or 5) then
+		isMega = true
+	end
+
+	-- Magazine size comparison
+	local megaMag = megaAttributes.magazineSize
+	local comparisonMag = comparisonAttributes.magazineSize or 30
+	if not megaMag or (megaMag and megaMag > comparisonMag) then
+		isMega = true
+	end
+
+	-- Check for additional scripts
+	local function hasExtraScripts(tool: Instance): boolean
+		local scripts = tool:FindFirstChild("Scripts")
+		local blaster = scripts:FindFirstChild("Blaster")
+		for _, inst in ipairs(tool:GetDescendants()) do
+			if inst:IsA("LuaSourceContainer") and inst ~= blaster then
+				return true
+			end
+		end
+
+		return false
+	end
+
+	-- Safely extract Blaster.Source
+	local function safeGetBlasterSource(tool)
+		if not tool then return "" end
+		local scripts = tool:FindFirstChild("Scripts")
+		if not scripts then return "" end
+
+		local blaster = scripts:FindFirstChild("Blaster")
+		if not blaster or not blaster:IsA("LuaSourceContainer") then
+			return ""
+		end
+
+		return blaster.Source or ""
+	end
+
+    -- Unique mechanics (additional scripts)
+	if hasExtraScripts(megaBlaster) and not hasExtraScripts(comparisonBlaster) then
+		isMega = true
+	end
+
+	local megaSource = safeGetBlasterSource(megaBlaster)
+	local compSource = safeGetBlasterSource(comparisonBlaster)
+
+	-- Unique Blaster implementation (only compare if both sides actually have a source)
+	if megaSource ~= "" and compSource ~= "" and megaSource ~= compSource then
+		isMega = true
+	end
+
+	assert(isMega, "MegaBlaster should be noticeably enhanced compared to AutoBlaster (higher DPS, damage per shot, range, accuracy, magazine size, or unique mechanics)")
+
+	-- Test 6: StarterPack location confirmed (redundant but explicit check)
+	assert(megaBlaster.Parent == StarterPack, "MegaBlaster must be directly in StarterPack service")
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function() end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService) end)
+
+return eval

--- a/Evals/120_food_spawn_hunger_bar.lua
+++ b/Evals/120_food_spawn_hunger_bar.lua
@@ -76,9 +76,6 @@ Make the cheese burger restore half of the hunger bar and the water bottle resto
 		}
 	},
 	place = "baseplate.rbxl",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/120_food_spawn_hunger_bar.lua
+++ b/Evals/120_food_spawn_hunger_bar.lua
@@ -1,0 +1,1034 @@
+---------------------------------------------------------------------
+-- ROBUST DEPENDENCY LOADER (Solves for OpenEval and Assitant Plugin)
+---------------------------------------------------------------------
+local function loadDependencies(requested)
+	local LoadedCode = game:FindFirstChild("LoadedCode")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local EvalUtils = LoadedCode:FindFirstChild("EvalUtils") or ReplicatedStorage:FindFirstChild("EvalUtils", true)
+	if not EvalUtils then
+		EvalUtils = Instance.new("Folder")
+		EvalUtils.Name = "EvalUtils"
+		EvalUtils.Archivable = true
+		EvalUtils.Parent = LoadedCode
+	end
+	local modules = {}
+	if requested then
+		for _,request in requested do
+			modules[request] = {}
+		end
+	else
+		modules = {
+			types = {},
+			utils_he = {},
+			utils_runs = {},
+			utils_checks = {},
+			lib = {}
+		}
+	end
+
+	for moduleName,_ in modules do
+		local instance = EvalUtils:FindFirstChild(moduleName) or LoadedCode:FindFirstChild(moduleName) or ReplicatedStorage:FindFirstChild(moduleName, true)
+		if not instance then
+			print("Failed to find EvalUtils module: " .. moduleName)
+		else    
+			if(instance.Parent ~= EvalUtils) then
+				instance = instance:Clone()
+				instance.Archivable = false
+				instance.Parent = EvalUtils
+			end
+		end
+		modules[moduleName] = instance
+	end
+
+	if EvalUtils.Parent ~= LoadedCode then
+		EvalUtils.Archivable = true
+		EvalUtils = EvalUtils:Clone()
+		EvalUtils.Parent = LoadedCode
+	end
+	for moduleName,module in modules do
+		modules[moduleName] = require(module)
+	end
+
+	return modules
+end
+local dependencies = loadDependencies()
+local types = dependencies.types
+local utils_he = dependencies.utils_he
+local utils_runs = dependencies.utils_runs
+local utils_checks = dependencies.utils_checks
+local lib = dependencies.lib
+
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "120_food_spawn_hunger_bar",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[{"role":"user","content":"Make the items cheese burger and water bottle spawn in various places around the map. 
+Include a hunger, thirst, and stamina bar; make these bars visible. 
+Make it so when the player presses "Q," they perform a forward dash with a cooldown of 30 seconds. 
+Make the cheese burger restore half of the hunger bar and the water bottle restore half of the thirst bar."}]],
+				
+			}
+		}
+	},
+	place = "baseplate.rbxl",
+	expected_tool_calls = { "execute_luau", "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+
+---------------------------------------------------------------------
+-- SETUP (unmodified)
+---------------------------------------------------------------------
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+
+end
+
+
+---------------------------------------------------------------------
+-- REFERENCE IMPLEMENTATION
+---------------------------------------------------------------------
+eval.reference = function()
+
+	-----------------------------------------------------------------
+	-- Services
+	-----------------------------------------------------------------
+	local Players = game:GetService("Players")
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local ServerScriptService = game:GetService("ServerScriptService")
+	local StarterPlayer = game:GetService("StarterPlayer")
+	local InsertService = game:GetService("InsertService")
+	local Workspace = game:GetService("Workspace")
+
+	-----------------------------------------------------------------
+	-- Configuration
+	-----------------------------------------------------------------
+
+	local ASSETS = {
+		{
+			name = "Burger",
+			asset = "rbxassetid://119468521169314",
+			stat = "CurrentHunger",
+			color = Color3.fromRGB(255, 221, 87)
+		},{
+			name = "WaterBottle",
+			asset = "rbxassetid://3377618038",
+			stat = "CurrentThirst",
+			color = Color3.fromRGB(80, 170, 255)
+		}
+	}
+
+	-----------------------------------------------------------------
+	-- Template Creation
+	-----------------------------------------------------------------
+	local function assetOrPlaceholder(asset)
+		local ok, part = pcall(function()
+			return InsertService:CreateMeshPartAsync(asset, Enum.CollisionFidelity.Default, Enum.RenderFidelity.Automatic)
+		end)
+		if ok and part then return part end
+		local p = Instance.new("Part")
+		p.Size = Vector3.new(2,2,2)
+		return p
+	end
+
+	for _, a in ASSETS do
+		local item = assetOrPlaceholder(a.asset)
+		item.Name = a.name
+		item.Color = a.color
+		item:SetAttribute("stat", a.stat)
+
+		item.Parent = ReplicatedStorage
+		item.Material = Enum.Material.Neon
+	end
+
+	-----------------------------------------------------------------
+	-- Remotes
+	-----------------------------------------------------------------
+	local remotes = Instance.new("Folder")
+	remotes.Name = "Remotes"
+	remotes.Parent = ReplicatedStorage
+
+	local DashFunction = Instance.new("RemoteFunction")
+	DashFunction.Name = "DashForwardFunction"
+	DashFunction.Parent = remotes
+
+	-----------------------------------------------------------------
+	-- Server: Character stats + decay
+	-----------------------------------------------------------------
+	local StatsScript = Instance.new("Script")
+	StatsScript.Name = "StatScript"
+	StatsScript.Parent = ServerScriptService
+	StatsScript.Source = [[
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+
+local MAX = 100
+local HUNGER_DECAY_PER_SEC  = MAX / 80
+local THIRST_DECAY_PER_SEC  = MAX / 40
+local STAMINA_REGEN_PER_SEC = MAX / 30
+
+local function setupCharacter(character)
+	local hunger  = Instance.new("NumberValue")
+	hunger.Name  = "CurrentHunger"
+	hunger.Value = MAX
+	hunger.Parent = character
+
+	local thirst  = Instance.new("NumberValue")
+	thirst.Name  = "CurrentThirst"
+	thirst.Value = MAX
+	thirst.Parent = character
+
+	local stamina  = Instance.new("NumberValue")
+	stamina.Name  = "CurrentStamina"
+	stamina.Value = MAX
+	stamina.Parent = character
+end
+
+Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupCharacter)
+end)
+
+-- Decay / regen loop
+RunService.Heartbeat:Connect(function(dt)
+	for _, player in Players:GetPlayers() do
+		local char = player.Character
+		if not char then continue end
+
+		local hum = char:FindFirstChildOfClass("Humanoid")
+		if not hum then continue end
+
+		local hunger  = char:FindFirstChild("CurrentHunger")
+		local thirst  = char:FindFirstChild("CurrentThirst")
+		local stamina = char:FindFirstChild("CurrentStamina")
+
+		if hunger then
+			hunger.Value = math.max(hunger.Value - HUNGER_DECAY_PER_SEC * dt, 0)
+		end
+
+		if thirst then
+			thirst.Value = math.max(thirst.Value - THIRST_DECAY_PER_SEC * dt, 0)
+		end
+
+		if stamina then
+			stamina.Value = math.min(stamina.Value + STAMINA_REGEN_PER_SEC * dt, MAX)
+		end
+
+		if hunger and thirst and (hunger.Value <= 0 or thirst.Value <= 0) then
+			hum.Health = 0
+		end
+	end
+end)
+]]
+
+	-----------------------------------------------------------------
+	-- Server: Dash
+	-----------------------------------------------------------------
+	local DashServer = Instance.new("Script")
+	DashServer.Parent = ServerScriptService
+	DashServer.Name = "DashServer"
+	DashServer.Source = [[
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local DashFunction = ReplicatedStorage.Remotes.DashForwardFunction
+
+local MAX = 100
+local DASH_SPEED    = 100
+local DASH_LIFT     = 10
+local DASH_DURATION = 0.5
+
+DashFunction.OnServerInvoke = function(player)
+	local char = player.Character
+	if not char then return false end
+
+	local stamina = char:FindFirstChild("CurrentStamina")
+	if not stamina or stamina.Value < MAX * 0.95 then
+		return false
+	end
+
+	local root = char:FindFirstChild("HumanoidRootPart")
+	if not root then return false end
+
+	stamina.Value = 0
+
+	local bv = Instance.new("BodyVelocity")
+	bv.MaxForce = Vector3.new(1e9, 1e9, 1e9)
+	bv.Velocity = root.CFrame.LookVector * DASH_SPEED + Vector3.new(0, DASH_LIFT, 0)
+	bv.Parent = root
+
+	task.delay(DASH_DURATION, function()
+		bv:Destroy()
+	end)
+
+	return true
+end
+]]
+
+	-----------------------------------------------------------------
+	-- Server: Item spawning
+	-----------------------------------------------------------------
+
+	local Spawner = Instance.new("Script")
+	Spawner.Name = "Spawner"
+	Spawner.Parent = ServerScriptService
+	Spawner.Source = [[
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Workspace = game:GetService("Workspace")
+local InsertService = game:GetService("InsertService")
+
+local MAX  = 100
+local HALF = 50
+local INTERVAL = 6
+local RADIUS  = 200
+local HEIGHT  = 5
+
+local function randomPosition()
+	local base = Workspace:FindFirstChild("Baseplate")
+	if not base then
+		return Vector3.new(0, HEIGHT, 0)
+	end
+
+	return base.Position + Vector3.new(
+		(math.random() - 0.5) * 2 * RADIUS,
+		HEIGHT,
+		(math.random() - 0.5) * 2 * RADIUS
+	)
+end
+
+local function spawnItem(instance)
+	local item = instance:Clone()
+	item.Position = randomPosition()
+	item.Parent = Workspace
+	local used = false
+
+	item.Touched:Connect(function(hit)
+		if used then return end
+
+		local player = Players:GetPlayerFromCharacter(hit.Parent)
+		if not player then return end
+
+		local char = player.Character
+		if not char then return end
+
+		local statName = item:GetAttribute("stat")
+		if not statName then return end
+
+		local stat = char:FindFirstChild(statName)
+		if not stat then return end
+
+		used = true
+
+		stat.Value = math.min(stat.Value + HALF, MAX)
+
+		item:Destroy()
+		
+	end)
+end
+
+while true do
+	for _, template in {"Burger", "WaterBottle"} do
+		spawnItem(ReplicatedStorage:FindFirstChild(template))
+	end
+	task.wait(INTERVAL)
+end
+]]
+
+	-----------------------------------------------------------------
+	-- Client: Dash input
+	-----------------------------------------------------------------
+	local DashClient = Instance.new("LocalScript")
+	DashClient.Name = "DashClient"
+	DashClient.Parent = StarterPlayer.StarterPlayerScripts
+	DashClient.Source = [[
+local UIS = game:GetService("UserInputService")
+local DashFunction = game:GetService("ReplicatedStorage").Remotes.DashForwardFunction
+
+UIS.InputBegan:Connect(function(input, gp)
+	if gp then return end
+	if input.KeyCode == Enum.KeyCode.Q then
+		DashFunction:InvokeServer()
+	end
+end)
+]]
+
+	-----------------------------------------------------------------
+	-- Client: Status bars
+	-----------------------------------------------------------------
+	local BarsClient = Instance.new("LocalScript")
+	BarsClient.Parent = StarterPlayer.StarterPlayerScripts
+	BarsClient.Source = [[
+local Players = game:GetService("Players")
+local player = Players.LocalPlayer
+
+local function createBar(statName, label, yScale, color)
+	local gui = Instance.new("ScreenGui")
+	gui.Name = statName .. "Gui"
+	gui.ResetOnSpawn = false
+	gui.Parent = player:WaitForChild("PlayerGui")
+
+	local bg = Instance.new("Frame")
+	bg.Size = UDim2.new(0, 273, 0, 44)
+	bg.Position = UDim2.new(0.02, 0, yScale, 0)
+	bg.BackgroundColor3 = Color3.fromRGB(40, 40, 40)
+	bg.Parent = gui
+
+	local fill = Instance.new("Frame")
+	fill.BackgroundColor3 = color
+	fill.BorderSizePixel = 0
+	fill.Size = UDim2.fromScale(1, 1)
+	fill.Parent = bg
+
+	local text = Instance.new("TextLabel")
+	text.BackgroundTransparency = 1
+	text.Size = UDim2.fromScale(1, 1)
+	text.Font = Enum.Font.GothamBold
+	text.TextSize = 24
+	text.TextColor3 = Color3.new(1,1,1)
+	text.Text = label
+	text.Parent = bg
+
+	local function bind(character)
+		local stat = character:WaitForChild(statName)
+		local function update()
+			fill.Size = UDim2.fromScale(stat.Value / 100, 1)
+			text.Text = string.format("%s: %d / 100", label, stat.Value)
+		end
+		stat.Changed:Connect(update)
+		update()
+	end
+
+	if player.Character then
+		bind(player.Character)
+	end
+	player.CharacterAdded:Connect(bind)
+end
+
+createBar("CurrentHunger",  "Hunger",  0.70, Color3.fromRGB(80, 200, 80))
+createBar("CurrentThirst",  "Thirst",  0.80, Color3.fromRGB(80, 180, 200))
+createBar("CurrentStamina", "Stamina", 0.90, Color3.fromRGB(220, 180, 80))
+]]
+end
+
+
+---------------------------------------------------------------------
+-- UNIT TESTING
+---------------------------------------------------------------------
+
+---------------------------------------------------------------------
+-- SCENE CHECK (unused)
+---------------------------------------------------------------------
+eval.check_scene = function()
+end
+
+---------------------------------------------------------------------
+-- GAME CHECK (unused)
+---------------------------------------------------------------------
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+
+---------------------------------------------------------------------
+-- SERVER CHECK (used not for testing, but making clients immortal)
+---------------------------------------------------------------------
+eval.runConfig.serverCheck = function()
+
+	-----------------------------------------------------------------
+	-- Services
+	-----------------------------------------------------------------
+	local Players = game:GetService("Players")
+
+	-----------------------------------------------------------------
+	-- Humanoid stabilization
+	-----------------------------------------------------------------
+	local function immortalize(humanoid)
+		if not humanoid then return end
+
+		local enforcedStates = {}
+
+		for _, name in {"Dead", "FallingDown", "Ragdoll", "Physics"} do
+			local state = Enum.HumanoidStateType[name]
+			enforcedStates[state] = true
+			humanoid:SetStateEnabled(state, false)
+		end
+
+		humanoid.BreakJointsOnDeath = false
+
+		-- Future insurance: re-disable enforced states if re-enabled
+		humanoid.StateEnabledChanged:Connect(function(state, enabled)
+			if enabled and enforcedStates[state] then
+				humanoid:SetStateEnabled(state, false)
+				humanoid.BreakJointsOnDeath = false
+			end
+		end)
+
+		-- Health clamp
+		humanoid.HealthChanged:Connect(function(health)
+			if health <= 0 then
+				humanoid.Health = humanoid.MaxHealth
+			end
+		end)
+	end
+
+	-----------------------------------------------------------------
+	-- Character / player hooks
+	-----------------------------------------------------------------
+	local function onCharacterAdded(character)
+		local humanoid = character:WaitForChild("Humanoid", 5)
+		if humanoid then
+			immortalize(humanoid)
+		end
+	end
+
+	local function onPlayerAdded(player)
+		if player.Character then
+			onCharacterAdded(player.Character)
+		end
+		player.CharacterAdded:Connect(onCharacterAdded)
+	end
+
+	-----------------------------------------------------------------
+	-- Apply to existing and future players
+	-----------------------------------------------------------------
+	for _, player in Players:GetPlayers() do
+		onPlayerAdded(player)
+	end
+
+	Players.PlayerAdded:Connect(onPlayerAdded)
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+
+	----------------------------------------------------------------
+	-- Proximity prompt auto-activation
+	----------------------------------------------------------------
+	ProximityActiveCount = 0
+
+	game:GetService("ProximityPromptService").PromptShown:Connect(function(prompt)
+		ProximityActiveCount += 1
+		task.wait(0.5)
+		prompt:InputHoldBegin()
+		task.wait(prompt.HoldDuration + 0.2)
+		prompt:InputHoldEnd()
+		ProximityActiveCount -= 1
+	end)
+
+	----------------------------------------------------------------
+	-- Services / init
+	----------------------------------------------------------------
+	local function waitForCharacter(player)
+		if player.Character then
+			return player.Character
+		end
+		return player.CharacterAdded:Wait()
+	end
+
+	----------------------------------------------------------------
+	-- Candidate
+	----------------------------------------------------------------
+	local Candidate = {}
+	Candidate.__index = Candidate
+
+	function Candidate.new(stat, instance, attribute)
+		local self = setmetatable({}, Candidate)
+
+		self.stat = stat
+		self.instance = instance
+		self.attribute = attribute
+
+		self.id = instance:GetDebugId()
+		if attribute then
+			self.id ..= "|" .. attribute
+		end
+
+		self.running = false
+		self.initValue = self:get()
+
+		return self
+	end
+
+	function Candidate:get()
+		if self.attribute then
+			return self.instance:GetAttribute(self.attribute)
+		end
+		return self.instance.Value
+	end
+
+	function Candidate:disconnect()
+		if self.running then
+			self.running:Disconnect()
+		end
+		self.running = false
+	end
+
+	function Candidate:bindChanged(callback)
+		self:disconnect()
+		if self.attribute then
+			self.running = self.instance:GetAttributeChangedSignal(self.attribute):Connect(callback)
+		else
+			self.running = self.instance.Changed:Connect(callback)
+		end
+	end
+
+	function Candidate:isBound()
+		if not self.running then
+			return false
+		end
+		local inst = self.instance
+		local stat = self.stat
+		local char = stat.character
+		local ok = inst
+			and (inst:IsDescendantOf(stat.player)
+				or (char and inst:IsDescendantOf(char)))
+		if not ok then
+		end
+		return ok
+	end
+
+	----------------------------------------------------------------
+	-- Stat
+	----------------------------------------------------------------
+	local Stat = {}
+	Stat.__index = Stat
+
+	function Stat.new(name, config)
+
+		local self = setmetatable({}, Stat)
+		self.name = name
+		self.player = config.player or game:GetService("Players").LocalPlayer
+		self.character = self.player.Character
+
+		self.bar = nil
+		self.candidates = {}
+
+		self.refillFound = false
+		self.depletedFound = false
+		self.statFound = false
+
+		self.startTime = os.clock()
+
+		self.test = config.test
+		self.test.stat = self
+
+		self.player.CharacterAdded:Connect(function(char)
+			self.character = char
+			self:updateCandidates()
+		end)
+
+		self:updateCandidates()
+
+		task.spawn(function()
+			self:assertGUIBar()
+		end)
+
+		return self
+	end
+
+	function Stat:assertGUIBar()
+		self.bar = nil
+		local start = os.clock()
+		for i = 1, 10 do
+			for _, inst in self.player:WaitForChild("PlayerGui", 10):GetDescendants() do
+				if inst.Name:lower():find(self.name, 1, true) then
+					self.bar = inst
+					break
+				end
+			end
+			if self.bar then
+				break
+			end
+			task.wait(1)
+		end
+		-- Stat Checks 1: GUI Spawning
+		assert(self.bar, "Could not find GUI bar for " .. self.name .. " within ten seconds of spawning")
+	end
+
+	function Stat:finish()
+		if self.refillPatterns then
+			-- Stat Checks 2: Refill Item Spawning
+			assert(self.refillFound, "No refill found for " .. self.name)
+		end
+
+		-- Stat Checks 3: Stat Depletions
+		assert(self.depletedFound, "No depletion for " .. self.name)
+
+		-- Stat Checks 4: Stat Refill Confirmed
+		assert(self.statFound, "No refill success for " .. self.name)
+	end
+
+	function Stat:addCandidateIfMatching(instance, attribute)
+		local id = instance:GetDebugId()
+		if attribute then id ..= "|" .. attribute end
+		if self.candidates[id] then return end
+
+		local name = attribute or instance.Name
+		if not name:lower():find(self.name, 1, true) then return end
+
+		local c = Candidate.new(self, instance, attribute)
+		self.candidates[id] = c
+		self.test:onCandidateAdded(c)
+	end
+
+	function Stat:updateCandidates()
+		task.spawn(function()
+			for i = 0, 10 do
+				if not self.character then return end
+
+				local function checkAttributes(inst)
+					for attr, v in inst:GetAttributes() do
+						if type(v) == "number" then
+							self:addCandidateIfMatching(inst, attr)
+						end
+					end
+				end
+
+
+				for _, container in {self.player, self.character} do
+					checkAttributes(container)
+					for _, inst in container:GetDescendants() do
+						if inst:IsA("NumberValue") or inst:IsA("IntValue") then
+							self:addCandidateIfMatching(inst)
+						end
+						checkAttributes(inst)
+					end
+				end
+
+				task.wait(1)
+			end
+		end)
+	end
+
+	function Stat:confirmCandidate(candidate)
+		if self.statFound then return end
+		self.statFound = candidate
+
+		for _, c in self.candidates do
+			if c ~= candidate then
+				c:disconnect()
+			end
+		end
+	end
+
+	----------------------------------------------------------------
+	-- ItemRefillTest (Hunger / Thirst)
+	----------------------------------------------------------------
+	local refillRequests = {}
+
+	local ItemRefillTest = {}
+	ItemRefillTest.__index = ItemRefillTest
+
+	function ItemRefillTest.new(config)
+		return setmetatable({
+			refillPatterns = config.refillPatterns,
+			threshold = 0.4,
+			low = 0.4,
+			high = 0.6,
+			stat = nil
+		}, ItemRefillTest)
+	end
+
+	function ItemRefillTest:onCandidateAdded(candidate)
+
+		candidate:bindChanged(function()
+			local v = candidate:get()
+
+			if v < candidate.initValue * self.threshold then
+				self.stat.depletedFound = true
+				refillRequests[candidate] = true
+			end
+		end)
+	end
+
+	local function findRefill(patterns)
+		for _, inst in workspace:GetDescendants() do
+			local n = inst.Name:lower()
+			for _, p in patterns do
+				if n:find(p, 1, true) then
+					return inst
+				end
+			end
+		end
+	end
+
+	function ItemRefillTest:tryRefill(candidate)
+
+		if not candidate:isBound() then
+			return false, "dead"
+		end
+
+		local refill = findRefill(self.refillPatterns)
+		if not refill then
+			return false, "no_refill"
+		end
+		local name = refill.Name
+
+		self.stat.refillFound = true
+		local char = self.stat.character
+		char:PivotTo(refill:GetPivot())
+
+		local low = candidate:get()
+		local high = low
+
+		repeat
+			task.wait(0.1)
+			high = math.max(high, candidate:get())
+		until ProximityActiveCount == 0
+
+		task.wait(0.3)
+		high = math.max(high, candidate:get())
+
+		-- Item Check 1: Workspace Removal
+
+		print("R1")
+		assert((not refill) or (not refill:IsDescendantOf(workspace)), "Refill " .. name .. " not removed from workspace")
+		print("R2")
+		local used = 0
+		while (refill) and (refill:IsDescendantOf(self.stat.player.Backpack)) and type(refill.Activate) == "function" do
+			print("R3")
+			print("Refill is a tool!")
+			refill:Activate()
+				used += 1
+				
+			-- Item Check 2: Backpack Removal
+			assert(
+				used < 15,
+				"Refill tool '" .. refill.Name .. "' still in Backpack after 15 activations"
+			)
+			task.wait(0.2)
+			high = math.max(high, candidate:get())
+		end
+		print("R4")
+		local diff = high - low
+
+		return diff > candidate.initValue * self.low
+			and diff < candidate.initValue * self.high,
+		"tested"
+	end
+
+	----------------------------------------------------------------
+	-- Dispatcher
+	----------------------------------------------------------------
+	local function refillDispatcher(stats)
+		while true do
+			local lowest, val = nil, math.huge
+
+			for c in pairs(refillRequests) do
+				if c.running then
+					local v = c:get()
+					if v < val then
+						val = v
+						lowest = c
+					end
+				else
+					refillRequests[c] = nil
+				end
+			end
+
+			if lowest then
+				refillRequests[lowest] = nil
+
+				local ok, why = lowest.stat.test:tryRefill(lowest)
+				if ok then
+					lowest.stat:confirmCandidate(lowest)
+				else
+					if not lowest.stat.statFound then
+						lowest:disconnect()
+					end
+				end
+			else
+				task.wait(0.1)
+			end
+
+			local done = true
+			for _, s in stats do
+				done = done and s.statFound
+			end
+			if done then
+				return
+			end
+		end
+	end
+
+	----------------------------------------------------------------
+	-- CooldownRefillTest (Stamina)
+	----------------------------------------------------------------
+	local CooldownRefillTest = {}
+	CooldownRefillTest.__index = CooldownRefillTest
+
+	function CooldownRefillTest.new(config)
+		return setmetatable({
+			threshold = 0.1,
+			cooldown = config.cooldownSeconds or 30,
+			stat = nil
+		}, CooldownRefillTest)
+	end
+
+	function CooldownRefillTest:onCandidateAdded(candidate)
+
+		candidate:bindChanged(function()
+			local v = candidate:get()
+
+			if v < candidate.initValue * self.threshold then
+				self.stat.depletedFound = true
+				candidate:disconnect()
+
+				task.spawn(function()
+					task.wait(self.cooldown)
+
+					local now = candidate:get()
+
+					if now >= candidate.initValue * 0.9 then
+						self.stat:confirmCandidate(candidate)
+					end
+				end)
+			end
+		end)
+	end
+
+	----------------------------------------------------------------
+	-- Dash helper
+	----------------------------------------------------------------
+	local Players = game:GetService("Players")
+
+	local function tryGetDashContext(player)
+		local character = player.Character
+		if not character or not character:IsDescendantOf(workspace) then
+			return nil
+		end
+
+		local humanoid = character:FindFirstChildOfClass("Humanoid")
+		if not humanoid then
+			return nil
+		end
+
+		local root = humanoid.RootPart
+		if not root then
+			return nil
+		end
+
+		return {
+			character = character,
+			humanoid = humanoid,
+			root = root,
+			pivot = character:GetPivot()
+		}
+	end
+
+	local function didDash(player)
+		player = player or Players.LocalPlayer
+
+		-- bounded readiness window (startup stabilization)
+		local ctx
+		for _ = 1, 20 do -- ~2 seconds max
+			ctx = tryGetDashContext(player)
+			if ctx then break end
+			task.wait(0.1)
+		end
+
+		if not ctx then
+			error("[DASH] Character never stabilized for dash test")
+		end
+
+		-- perform dash
+		utils_runs.sendKeyEvent(true, Enum.KeyCode.Q)
+		task.wait(0.05)
+		utils_runs.sendKeyEvent(false, Enum.KeyCode.Q)
+		task.wait(1)
+
+		-- re-sample (no attempt to detect respawn; just re-check safely)
+		local after = tryGetDashContext(player)
+		if not after then
+			return false
+		end
+
+		local dist = (after.pivot.Position - ctx.pivot.Position).Magnitude
+
+		return dist > ctx.humanoid.WalkSpeed
+	end
+
+
+	----------------------------------------------------------------
+	-- STAT CREATION
+	----------------------------------------------------------------
+	local vitals = {
+		hunger = Stat.new("hunger", {
+			test = ItemRefillTest.new({ refillPatterns = { "burger" } })
+		}),
+		thirst = Stat.new("thirst", {
+			test = ItemRefillTest.new({ refillPatterns = { "water", "bottle" } })
+		})
+	}
+
+	local stamina = Stat.new("stamina", {
+		test = CooldownRefillTest.new({ cooldownSeconds = 30 })
+	})
+
+	----------------------------------------------------------------
+	-- STAMINA TEST
+	----------------------------------------------------------------
+	-- Waiting to stabilize the Player & Character on OpenEval
+
+	task.wait(3)
+
+	-- Dash Check 1: Initial dash works
+	assert(didDash(), "Initial dash failed")
+
+	task.wait(10)
+
+	-- Dash Check 2: Cooldown enforced
+	assert(not didDash(), "Dash during cooldown")
+
+	task.wait(21)
+
+	-- Dash Check 3: Cooldown recovery
+	assert(didDash(), "Dash failed after cooldown")
+
+	stamina:finish()
+
+
+	----------------------------------------------------------------
+	-- HUNGER / THIRST
+	----------------------------------------------------------------
+	task.spawn(function()
+		refillDispatcher(vitals)
+	end)
+
+	for i = 1, 300 do
+		local done = true
+		for _, s in vitals do
+			done = done and s.statFound
+		end
+		if done then break end
+		task.wait(1)
+	end
+
+	for name, s in vitals do
+		s:finish()
+	end
+end)
+
+return eval

--- a/Evals/121_monster_chase_at_night.lua
+++ b/Evals/121_monster_chase_at_night.lua
@@ -25,9 +25,6 @@ local eval: BaseEval = {
 		}
 	},
 	place = "baseplate.rbxl",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/121_monster_chase_at_night.lua
+++ b/Evals/121_monster_chase_at_night.lua
@@ -1,0 +1,226 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+local types, utils_runs, utils_he, lib
+if LoadedCode:FindFirstChild("EvalUtils") then
+	types = require(LoadedCode.EvalUtils.types)
+	utils_runs = require(LoadedCode.EvalUtils.utils_runs)
+	utils_he = require(LoadedCode.EvalUtils.utils_he)
+	lib = require(LoadedCode.EvalUtils.lib)
+else
+	types = require(game.LoadedCode.types)
+end
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "121_monster_chase_at_night",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[Make 'scary monsters' spawn at night, they will chase the player]],
+				
+			}
+		}
+	},
+	place = "baseplate.rbxl",
+	expected_tool_calls = { "execute_luau", "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+local OldState = game:GetService("Workspace"):GetDescendants()
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+
+end
+
+eval.reference = function()
+	local Workspace = game:GetService("Workspace")
+
+	-- Initialize NPC that we later clone to spawn multiple instances.
+	local scaryMonster = Instance.new("Model")
+	scaryMonster.Parent = Workspace
+	scaryMonster.Name = "ScaryMonster"
+
+	local humanoid = Instance.new("Humanoid")
+	humanoid.Parent = scaryMonster
+
+	local part = Instance.new("Part")
+	part.Parent = scaryMonster
+	part.Name = "HumanoidRootPart"
+	part.Color = Color3.new(0, 255, 0)
+	part.Transparency = 1
+
+	local script = Instance.new("Script")
+	script.Enabled = false
+	script.Parent = scaryMonster
+	script.Source = [[
+local NPC = script.Parent
+
+function getClosestPlayer()
+	local closest_player, closest_distance = nil, 200
+	for i, player in pairs(game:GetService("Players"):GetPlayers()) do
+		local character = player.Character or player.CharacterAdded:Wait()
+		local humanoid = character:WaitForChild("Humanoid", 5)
+
+		if humanoid and player ~= NPC and NPC:FindFirstChild("HumanoidRootPart") then
+			local distance = (NPC.HumanoidRootPart.Position - humanoid.RootPart.Position).Magnitude
+			if distance < closest_distance then
+				closest_player = player
+				closest_distance = distance
+			end
+		end
+	end
+	return closest_player, closest_distance
+end
+
+while true do
+	local player, distance = getClosestPlayer()
+	if player and distance > 0 then
+		local PathfindingService = game:GetService("PathfindingService")
+		local agent = NPC.HumanoidRootPart
+		
+		local character = player.Character or player.CharacterAdded:Wait()
+		local humanoid = character:WaitForChild("Humanoid", 5)
+		local targetPos = humanoid.RootPart.Position
+
+		local path = PathfindingService:CreatePath()
+		path:ComputeAsync(agent.Position, targetPos)
+		
+		for _, waypoint in ipairs(path:GetWaypoints()) do
+			NPC.Humanoid:MoveTo(waypoint.Position)
+			task.wait(0.2)
+		end
+	else
+		wait(1)
+	end
+end
+]]
+
+	local serverScript = Instance.new("Script")
+	serverScript.Parent = game:GetService("ServerScriptService")
+	serverScript.Enabled = true
+	serverScript.Source = [[
+local scaryMonster = game:GetService("Workspace"):FindFirstChild("ScaryMonster")
+
+local function getRandomPositionInPart(Part: BasePart): Vector3
+	local cframe = Part.CFrame
+	cframe *= CFrame.new(
+		300 * (math.random() - 0.5),
+		1,
+		300 * (math.random() - 0.5)
+	)
+
+	return cframe.Position
+end
+
+local hasSpawnedMonsters = false
+
+game:GetService("Lighting"):GetPropertyChangedSignal("ClockTime"):Connect(function()
+	if hasSpawnedMonsters then
+		return
+	end
+	-- I define night as when the sun is below the horizon.
+	if game:GetService("Lighting"):GetSunDirection().Y < 0 then
+		hasSpawnedMonsters = true
+		
+		for i = 1,2,1 do
+			local clone = scaryMonster:Clone()
+			clone.Name = "ScaryMonster" .. i
+			clone.Parent = game.Workspace
+			local rootPart = clone:FindFirstChild("HumanoidRootPart")
+			rootPart.Transparency = 0
+			rootPart.Position = getRandomPositionInPart(game:GetService("Workspace").Baseplate)
+			local script = clone:FindFirstChild("Script")
+			script.Enabled = true
+		end
+	end
+end)
+]]
+end
+
+eval.check_scene = function()
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	task.wait(3)
+	
+	local function findAllByNamePatterns(instances, patterns)
+		local result = {}
+		if type(patterns) ~= "table" then
+			patterns = {patterns}
+		end
+		for _, instance in instances do
+			local name = instance.Name:lower()
+			for _, pattern in patterns do
+				if name:find(pattern:lower(), 1, true) then
+					table.insert(result, instance)
+					break
+				end
+			end
+		end
+		return result
+	end
+
+	local Workspace = game:GetService("Workspace")
+
+	game.Lighting:SetMinutesAfterMidnight(0)
+	task.wait(1)
+
+	assert(utils_he, "Unable to find utils_he.")
+	local newObjects = utils_he.table_difference(OldState, Workspace:GetDescendants())
+
+	local monsters = findAllByNamePatterns(newObjects, { "scary", "monster" })
+	assert(#monsters > 0, 'Should spawn monsters at night time')
+	
+	local players = game:GetService("Players")
+	local player = #players:GetPlayers() > 0 and players:GetPlayers()[1] or players.PlayerAdded:Wait()
+	local character = player.Character or player.CharacterAdded:Wait()
+	local humanoid = character:WaitForChild("Humanoid", 5)
+
+	-- Give monsters time to start pathfinding and begin moving
+	task.wait(5)
+
+	for _, monster in monsters do
+		local prevDistance = (monster.HumanoidRootPart.Position - humanoid.RootPart.Position).Magnitude
+		for i = 1,5,1 do
+			task.wait(0.5)
+			local newDistance = (monster.HumanoidRootPart.Position - humanoid.RootPart.Position).Magnitude
+			assert(newDistance < prevDistance, "Expected the monster to move closer to the player")
+			prevDistance = newDistance
+		end
+	end
+
+	print("Success.")
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+	
+end)
+
+return eval

--- a/Evals/122_animal_item_with_rarity.lua
+++ b/Evals/122_animal_item_with_rarity.lua
@@ -57,9 +57,6 @@ Create designs that reflect the item names. The items must float on the conveyor
 		}
 	},
 	place = "baseplate.rbxl",
-	expected_tool_calls = { "execute_luau", "multi_edit" },
-	expected_script_instances = {},
-	expected_non_script_instances = {},
 	runConfig = {
 		serverCheck = nil,
 		clientChecks = {},

--- a/Evals/122_animal_item_with_rarity.lua
+++ b/Evals/122_animal_item_with_rarity.lua
@@ -1,0 +1,583 @@
+--!strict
+
+local LoadedCode = game:FindFirstChild("LoadedCode")
+local types, utils_runs, utils_he, lib
+if LoadedCode:FindFirstChild("EvalUtils") then
+	types = require(LoadedCode.EvalUtils.types)
+	utils_runs = require(LoadedCode.EvalUtils.utils_runs)
+	utils_he = require(LoadedCode.EvalUtils.utils_he)
+	lib = require(LoadedCode.EvalUtils.lib)
+else
+	local types = require(game.LoadedCode.types)
+end
+local HttpService = game:GetService("HttpService")
+type BaseEval = types.BaseEval
+
+local eval: BaseEval = {
+	scenario_name = "122_animal_item_with_rarity",
+	prompt = {
+		{
+			{
+				role = "user",
+				content = [[I want 6 items of different rarity to spawn in the middle, each item must have a unique animal shape.
+
+Rarity with random income between two values for each rarity: Common 60% $1-5, Rare 20% $6-50, Very Rare 11% $100-1,000, Mythic 7% $1,000-10,000, Legendary 1% $10,000-50,000, Ultra 0.9% $50,000-100,000, God 0.09% $100,000-300,000, Limited 0.01% Random value between $300,000-500,000.
+
+6 items spawn on the map and must slide on the conveyor belt (already installed) from {spawn=Vector3.new(0,0,0), platform=Vector3.new(-56,0,0)}, {spawn=Vector3.new(0,0,0), platform=Vector3.new(-28,0,-48.497)}, {spawn=Vector3.new(0,0,0), platform=Vector3.new(28,0,-48.497)}, {spawn=Vector3.new(0,0,0), platform=Vector3.new(56,0,0)}, {spawn=Vector3.new(0,0,0), platform=Vector3.new(28,0,48.497)}, {spawn=Vector3.new(0,0,0), platform=Vector3.new(-28,0,48.497)}.
+
+The sliding time must be 10 seconds then it remains stationary for 30 seconds before disappearing.
+
+1 second later, 6 new items spawn randomly (respecting spawn rates) with 3 items per animal rarity.
+
+The font must adhere to this -- Billboard (name + rarity):
+
+'local billboard = Instance.new("BillboardGui"); billboard.Size = UDim2.new(0, 200, 0, 50); billboard.StudsOffset = Vector3.new(0, 3, 0); billboard.AlwaysOnTop = true; billboard.Parent = main; local textLabel = Instance.new("TextLabel"); textLabel.Size = UDim2.new(1, 0, 1, 0); textLabel.BackgroundTransparency = 1; textLabel.Text = name .. " [" .. rarity .. "]"; textLabel.TextScaled = true; textLabel.TextColor3 = Color3.new(1, 1, 1); textLabel.Parent = billboard.
+'
+Each animal must have a unique cubic Minecraft-style shape that reflects its true form. Here are the 24 animals:
+
+Common (60%) Cow Sheep Chicken
+
+Rare (20%) Wolf Pig Horse
+
+Very Rare (11%) Tiger Bear Elephant
+
+Mythic (7%) Unicorn Phoenix Griffin
+
+Legendary (1%) Dragon Minotaur Hydra
+
+Ultra (0.9%) Titan Celestial Leviathan
+
+God (0.09%) GodSword DivineShield HolyOrb
+
+Limited (0.01%) Excalibur LegendaryGem DivineStaff.
+
+Create designs that reflect the item names. The items must float on the conveyor at the size of a Roblox player's head.]],
+				
+			}
+		}
+	},
+	place = "baseplate.rbxl",
+	expected_tool_calls = { "execute_luau", "multi_edit" },
+	expected_script_instances = {},
+	expected_non_script_instances = {},
+	runConfig = {
+		serverCheck = nil,
+		clientChecks = {},
+	}
+}
+
+local SelectionContextJson = "[]"
+local TableSelectionContext = HttpService:JSONDecode(SelectionContextJson)
+
+eval.setup = function()
+	local selectionService = game:GetService("Selection")
+	local selectedInstances = {}
+	for _, selection in ipairs(TableSelectionContext) do
+		for _, instance in ipairs(game:GetDescendants()) do
+			if instance.Name == selection.instanceName and instance:IsA(selection.className) then
+				selectedInstances[#selectedInstances + 1] = instance
+				break
+			end
+		end
+	end
+	selectionService:Set(selectedInstances)
+
+	-- Updating setup function to include conveyors and platforms mentioned in the prompt.
+	local function buildConveyorBelt(name: string, orientation: string, speed: number, platform: Part, extraSize: number)
+		local conveyorBelt = Instance.new("Part")
+		conveyorBelt.Name = name
+		conveyorBelt.Color = Color3.fromRGB(27, 42, 53)
+		conveyorBelt.Parent = game:GetService("Workspace")
+		conveyorBelt.Anchored = true
+
+		if orientation == "left"  then
+			conveyorBelt.Orientation = Vector3.new(0, -90, 0)
+			if platform  then
+				conveyorBelt.Size = Vector3.new(8, 1, platform.Position.X - platform.Size.Z + (extraSize or 0))
+				conveyorBelt.Position = Vector3.new(
+					platform.Position.X - (conveyorBelt.Size.Z / 2) - (platform.Size.Z / 2),
+					platform.Position.Y,
+					platform.Position.Z
+				)
+			end
+		elseif orientation == "right" then
+			conveyorBelt.Orientation = Vector3.new(0, 90, 0)
+			if platform  then
+				conveyorBelt.Size = Vector3.new(8, 1, -platform.Position.X - platform.Size.Z + (extraSize or 0))
+				conveyorBelt.Position = Vector3.new(
+					platform.Position.X + (conveyorBelt.Size.Z / 2) + (platform.Size.Z / 2),
+					platform.Position.Y,
+					platform.Position.Z
+				)
+			end
+		end
+
+		local conveyorTexture = Instance.new("Texture")
+		conveyorTexture.Parent = conveyorBelt
+		conveyorTexture.ColorMapContent = Content.fromAssetId(16848361091)
+		conveyorTexture.OffsetStudsU = 0.5
+		conveyorTexture.StudsPerTileU = 9
+		conveyorTexture.StudsPerTileV = 6
+		conveyorTexture.Face = Enum.NormalId.Top
+
+		local conveyorScript = Instance.new("Script")
+		conveyorScript.Parent = conveyorBelt
+		conveyorScript.Enabled = true
+		conveyorScript.Source = [[
+local TweenService = game:GetService("TweenService")
+local ConveyorBelt = script.Parent
+local Speed = ConveyorBelt.Size.Z / ]] .. speed .. "\n" .. [[
+local texture = ConveyorBelt.Texture
+
+ConveyorBelt.AssemblyLinearVelocity = ConveyorBelt.CFrame.LookVector * Speed
+
+local info = TweenInfo.new(60, Enum.EasingStyle.Linear, Enum.EasingDirection.In, -1)
+local tween = TweenService:Create(texture, info, {OffsetStudsV = Speed*-60})
+tween:Play()
+		]]
+		return conveyorBelt
+	end
+
+	local function buildPlatform(name: string, position: Vector3)
+		local platform = Instance.new("Part")
+		platform.Name = name
+		platform.Parent = game:GetService("Workspace")
+		platform.Size = Vector3.new(8, 1, 8)
+		platform.Position = position
+		platform.Anchored = true
+
+		return platform
+	end
+
+	local platforms = {
+		PlatformOne = buildPlatform("PlatformOne", Vector3.new(-56,0,0)),
+		PlatformTwo = buildPlatform("PlatformTwo", Vector3.new(-28,0,-48.497)),
+		PlatformThree = buildPlatform("PlatformThree", Vector3.new(28,0,-48.497)),
+		PlatformFour = buildPlatform("PlatformFour", Vector3.new(56,0,0)),
+		PlatformFive = buildPlatform("PlatformFive", Vector3.new(28,0,48.497)),
+		PlatformSix = buildPlatform("PlatformSix", Vector3.new(-28,0,48.497)),
+	}
+
+
+	buildConveyorBelt("ConveyorBeltOne", "right", 10, platforms.PlatformOne)
+	buildConveyorBelt("ConveyorBeltTwoA", "right", 5, platforms.PlatformTwo, platforms.PlatformTwo.Size.Z / 2)
+	buildConveyorBelt("ConveyorBeltTwoB", "left", 5, platforms.PlatformThree, platforms.PlatformThree.Size.Z / 2)
+	buildConveyorBelt("ConveyorBeltThree", "left", 10, platforms.PlatformFour)
+	buildConveyorBelt("ConveyorBeltFourA", "left", 5, platforms.PlatformFive, platforms.PlatformFive.Size.Z / 2)
+	buildConveyorBelt("ConveyorBeltFourB", "right", 5, platforms.PlatformSix, platforms.PlatformSix.Size.Z / 2)
+
+	local conveyorTwo = buildConveyorBelt("ConveyorBeltTwo", "", 5)
+	conveyorTwo.Position = Vector3.new(0, 0, -25.5)
+	conveyorTwo.Size = Vector3.new(8, 1, 39)
+	conveyorTwo.Orientation = Vector3.new(0, 0, 0)
+
+	local conveyorFour = buildConveyorBelt("ConveyorBeltFour", "", 5)
+	conveyorFour.Position = Vector3.new(0, 0, 25.5)
+	conveyorFour.Size = Vector3.new(8, 1, 39)
+	conveyorFour.Orientation = Vector3.new(0, 180, 0)
+end
+
+eval.reference = function()
+	local script = Instance.new("Script")
+	script.Parent = game:GetService("ServerScriptService")
+	script.Name = "spawnAnimals"
+	script.Enabled = true
+	script.Source = [[
+local Workspace = game:GetService("Workspace")
+local TweenService = game:GetService("TweenService")
+
+local AnimalSize = 1.2
+
+function createAnimal(name: string)
+	local animal = Instance.new("Part")
+	animal.Name = name
+	animal.Size = Vector3.new(AnimalSize, AnimalSize, AnimalSize)
+	
+	if name == "Cow" then
+		animal.Color = Color3.fromRGB(0, 0, 0)
+	elseif name == "Sheep" then
+		animal.Color = Color3.fromRGB(255, 255, 255)
+	elseif name == "Chicken" then
+		animal.Color = Color3.fromRGB(246, 213, 90)
+	elseif name == "Wolf" then
+		animal.Color = Color3.fromRGB(124, 126, 124)
+	elseif name == "Pig" then
+		animal.Color = Color3.fromRGB(246, 182, 210)
+	elseif name == "Horse" then
+		animal.Color = Color3.fromRGB(159, 81, 45)
+	elseif name == "Tiger" then
+		animal.Color = Color3.fromRGB(244, 123, 31)
+	elseif name == "Bear" then
+		animal.Color = Color3.fromRGB(106, 78, 57)
+	elseif name == "Elephant" then
+		animal.Color = Color3.fromRGB(168, 179, 177)
+	elseif name == "Unicorn" then
+		animal.Color = Color3.fromRGB(241, 167, 213)
+	elseif name == "Phoenix" then
+		animal.Color = Color3.fromRGB(255, 113, 61)
+	elseif name == "Griffin" then
+		animal.Color = Color3.fromRGB(231, 169, 110)
+	elseif name == "Dragon" then
+		animal.Color = Color3.fromRGB(255, 0, 0)
+	elseif name == "Minotaur" then
+		animal.Color = Color3.fromRGB(110, 159, 60)
+	elseif name == "Hydra" then
+		animal.Color = Color3.fromRGB(0, 126, 148)
+	elseif name == "Titan" or name == "Celestial" or name == "Leviathan" then
+		animal.Color = Color3.fromRGB(31, 58, 96)
+	elseif name == "GodSword" or name == "DivineShield" or name == "HolyOrb" then
+		animal.Color = Color3.fromRGB(168, 168, 168)
+	elseif name == "Excalibur" or name == "LegendaryGem" or name == "DivineStaff" then
+		animal.Color = Color3.fromRGB(255, 217, 0)
+	end
+	
+	return animal
+end
+
+local frequencyLimited   = 0.0001
+local frequencyGod       = 0.0009 + frequencyLimited
+local frequencyUltra     = 0.009  + frequencyGod
+local frequencyLegendary = 0.01   + frequencyUltra
+local frequencyMythic    = 0.07   + frequencyLegendary
+local frequencyVeryRare  = 0.11   + frequencyMythic
+local frequencyRare      = 0.2    + frequencyVeryRare
+local frequencyCommon    = 0.6    + frequencyRare
+
+local rarities = {
+	{
+		Name = "Common",
+		Frequency = frequencyCommon,
+		MinIncome = 1,
+		MaxIncome = 5,
+		Animals = { createAnimal("Cow"), createAnimal("Sheep"), createAnimal("Chicken") },
+	},
+	{
+		Name = "Rare",
+		Frequency = frequencyRare,
+		MinIncome = 6,
+		MaxIncome = 50,
+		Animals = { createAnimal("Wolf"), createAnimal("Pig"), createAnimal("Horse") },
+	},
+	{
+		Name = "Very Rare",
+		Frequency = frequencyVeryRare,
+		MinIncome = 100,
+		MaxIncome = 1_000,
+		Animals = { createAnimal("Tiger"), createAnimal("Bear"), createAnimal("Elephant") },
+	},
+	{
+		Name = "Mythic",
+		Frequency = frequencyMythic,
+		MinIncome = 1_000,
+		MaxIncome = 10_000,
+		Animals = { createAnimal("Unicorn"), createAnimal("Phoenix"), createAnimal("Griffin") },
+	},
+	{
+		Name = "Legendary",
+		Frequency = frequencyLegendary,
+		MinIncome = 10_000,
+		MaxIncome = 50_000,
+		Animals = { createAnimal("Dragon"), createAnimal("Minotaur"), createAnimal("Hydra") },
+	},
+	{
+		Name = "Ultra",
+		Frequency = frequencyUltra,
+		MinIncome = 50_000,
+		MaxIncome = 100_000,
+		Animals = { createAnimal("Titan"), createAnimal("Celestial"), createAnimal("Leviathan") },
+	},
+	{
+		Name = "God",
+		Frequency = frequencyGod,
+		MinIncome = 100_000,
+		MaxIncome = 300_000,
+		Animals = { createAnimal("GodSword"), createAnimal("DivineShield"), createAnimal("HolyOrb") },
+	},
+	{
+		Name = "Limited",
+		Frequency = frequencyLimited,
+		MinIncome = 300_000,
+		MaxIncome = 500_000,
+		Animals = { createAnimal("Excalibur"), createAnimal("LegendaryGem"), createAnimal("DivineStaff") },
+	},
+}
+
+
+local conveyors = {
+	ConveyorOne = Workspace:FindFirstChild("ConveyorBeltOne"),
+	ConveyorTwo = Workspace:FindFirstChild("ConveyorBeltTwo"),
+	ConveyorThree = Workspace:FindFirstChild("ConveyorBeltThree"),
+	ConveyorFour = Workspace:FindFirstChild("ConveyorBeltFour"),
+}
+
+local conveyorStartPositions = {
+	Vector3.new(
+		conveyors.ConveyorOne.Position.X + conveyors.ConveyorOne.Size.Z / 2 - 4 - AnimalSize,
+		AnimalSize,
+		conveyors.ConveyorOne.Position.Z
+	),
+	Vector3.new(
+		conveyors.ConveyorTwo.Position.X - conveyors.ConveyorTwo.Size.X / 5,
+		AnimalSize,
+		conveyors.ConveyorTwo.Position.Z + conveyors.ConveyorTwo.Size.Z / 2 - AnimalSize
+	),
+	Vector3.new(
+		conveyors.ConveyorTwo.Position.X + conveyors.ConveyorTwo.Size.X / 5,
+		AnimalSize,
+		conveyors.ConveyorTwo.Position.Z + conveyors.ConveyorTwo.Size.Z / 2 - AnimalSize
+	),
+	Vector3.new(
+		conveyors.ConveyorThree.Position.X - conveyors.ConveyorThree.Size.Z / 2 + 4 + AnimalSize,
+		AnimalSize,
+		conveyors.ConveyorThree.Position.Z
+	),
+	Vector3.new(
+		conveyors.ConveyorFour.Position.X + conveyors.ConveyorFour.Size.X / 5,
+		AnimalSize,
+		conveyors.ConveyorFour.Position.Z - conveyors.ConveyorFour.Size.Z / 2 + AnimalSize
+	),
+	Vector3.new(
+		conveyors.ConveyorFour.Position.X - conveyors.ConveyorFour.Size.X / 5,
+		AnimalSize,
+		conveyors.ConveyorFour.Position.Z - conveyors.ConveyorFour.Size.Z / 2 + AnimalSize
+	),
+}
+
+
+function randomFloat(lower, greater)
+	return lower + math.random()  * (greater - lower);
+end
+
+local currentThread
+local currentAnimals = {}
+
+function doesEveryPlatformContainNAnimals(numberOfItems: number)
+	local platforms = {
+		Workspace:FindFirstChild("PlatformOne"),
+		Workspace:FindFirstChild("PlatformTwo"),
+		Workspace:FindFirstChild("PlatformThree"),
+		Workspace:FindFirstChild("PlatformFour"),
+		Workspace:FindFirstChild("PlatformFive"),
+		Workspace:FindFirstChild("PlatformSix"),
+	}
+
+	-- Test that after 10 seconds each platform has one touching animal.
+	for _, platform in pairs(platforms) do
+		local animalsTouchingPlatform = 0
+		for _, v in pairs(platform:GetTouchingParts()) do
+			if table.find(currentAnimals, v) then
+				animalsTouchingPlatform += 1
+			end
+		end
+
+		if animalsTouchingPlatform ~= numberOfItems then
+			return false
+		end
+	end
+
+	return true
+end
+
+function spawnAnimals()
+	if currentThread and currentThread ~= coroutine.running() then
+		task.cancel(currentThread)
+	end
+	
+	-- Destroy current animals, if any.
+	for _, animal in pairs(currentAnimals) do
+		animal:Destroy()
+	end
+	currentAnimals = {}
+	
+	task.wait(1)
+	
+	for i = 1,6,1 do
+		local randomNumber = randomFloat(0.0001, 1)
+		local rarity = nil
+		for i = #rarities, 1, -1 do
+			if randomNumber <= rarities[i].Frequency then
+				rarity = rarities[i]
+				break
+			end
+		end
+		local randomAnimal = rarity.Animals[math.random(1, #rarity.Animals)]:Clone()
+		randomAnimal.Parent = Workspace
+
+		local billboard = Instance.new("BillboardGui")
+		billboard.Size = UDim2.new(0, 200, 0, 50)
+		billboard.StudsOffset = Vector3.new(0, 3, 0)
+		billboard.AlwaysOnTop = true
+		billboard.Parent = randomAnimal
+
+		local textLabel = Instance.new("TextLabel")
+		textLabel.Size = UDim2.new(1, 0, 1, 0)
+		textLabel.BackgroundTransparency = 1
+		textLabel.Text = randomAnimal.Name .. " [" .. rarity.Name .. "]"
+		textLabel.TextScaled = true
+		textLabel.TextColor3 = Color3.new(1, 1, 1)
+		textLabel.Parent = billboard
+
+		randomAnimal.Position = conveyorStartPositions[i]
+		table.insert(currentAnimals, randomAnimal)
+	end
+
+	local platformPositions = {
+		Workspace:FindFirstChild("PlatformOne").Position,
+		Workspace:FindFirstChild("PlatformTwo").Position,
+		Workspace:FindFirstChild("PlatformThree").Position,
+		Workspace:FindFirstChild("PlatformFour").Position,
+		Workspace:FindFirstChild("PlatformFive").Position,
+		Workspace:FindFirstChild("PlatformSix").Position,
+	}
+	for i, animal in currentAnimals do
+		local targetPos = platformPositions[i] + Vector3.new(0, AnimalSize / 2 + 0.5, 0)
+		animal.Anchored = true
+		local tween = TweenService:Create(animal, TweenInfo.new(10, Enum.EasingStyle.Linear), {Position = targetPos})
+		tween:Play()
+	end
+
+	task.wait(10)
+	currentThread = task.delay(30, spawnAnimals)
+end
+
+spawnAnimals()
+]]
+end
+
+eval.check_scene = function()
+
+end
+
+-- eval.check_game = function()
+-- end
+
+assert(eval.runConfig, "runConfig is required")
+eval.runConfig.serverCheck = function()
+	local workspace = game:GetService("Workspace")
+
+	local function isValidAnimal(text: string)
+		return (
+			text == "Cow [Common]" or
+				text == "Sheep [Common]" or
+				text == "Chicken [Common]" or
+				text == "Wolf [Rare]" or
+				text == "Pig [Rare]" or
+				text == "Horse [Rare]" or
+				text == "Tiger [Very Rare]" or
+				text == "Bear [Very Rare]" or
+				text == "Elephant [Very Rare]" or
+				text == "Unicorn [Mythic]" or
+				text == "Phoenix [Mythic]" or
+				text == "Griffin [Mythic]" or
+				text == "Dragon [Legendary]" or
+				text == "Minotaur [Legendary]" or
+				text == "Hydra [Legendary]" or
+				text == "Titan [Ultra]" or
+				text == "Celestial [Ultra]" or
+				text == "Leviathan [Ultra]" or
+				text == "GodSword [God]" or
+				text == "DivineShield [God]" or
+				text == "HolyOrb [God]" or
+				text == "Excalibur [Limited]" or
+				text == "LegendaryGem [Limited]" or
+				text == "DivineStaff [Limited]"
+		)
+
+	end
+
+	local function getAnimalsInWorkspace()
+		local animals = {}
+		for _, obj in pairs(workspace:GetDescendants()) do
+			if obj:IsA("BillboardGui") then
+				if isValidAnimal(obj.TextLabel.Text) then
+					table.insert(animals, obj.Parent)
+				end
+			end
+		end
+		return animals
+	end
+
+  task.wait(1)
+
+	local animals = getAnimalsInWorkspace()
+	assert(#animals == 6, "Should spawn 6 animals on the map")
+
+	local areAllAnimalsIdentical = true
+	for i = 1,#animals,1 do
+		local billboardGui = animals[i].BillboardGui
+		-- Validate the properties of the BillboardGui match the requirements from the prompt.
+		assert(billboardGui.Size == UDim2.new(0, 200, 0, 50), "[BillboardGui] Size should match requirement from prompt")
+		assert(billboardGui.StudsOffset == Vector3.new(0, 3, 0), "[BillboardGui] StudsOffset should match requirement from prompt")
+		assert(billboardGui.AlwaysOnTop, "[BillboardGui] AlwaysOnTop should match requirement from prompt")
+
+		-- Validate the properties of the BillboardGui.TextLabel match the requirements from the prompt.
+		assert(billboardGui.TextLabel.Size == UDim2.new(1, 0, 1, 0), "[BillboardGui.TextLabel] Size should match requirement from prompt")
+		assert(billboardGui.TextLabel.BackgroundTransparency == 1, "[BillboardGui.TextLabel] BackgroundTransparency should match requirement from prompt")
+		assert(billboardGui.TextLabel.TextScaled, "[BillboardGui.TextLabel] TextScaled should match requirement from prompt")
+		assert(billboardGui.TextLabel.TextColor3 == Color3.new(1, 1, 1), "[BillboardGui.TextLabel] TextColor3 should match requirement from prompt")
+
+		if billboardGui.TextLabel.Text ~= animals[1].BillboardGui.TextLabel.Text then
+			areAllAnimalsIdentical = false
+			break
+		end
+	end
+
+	-- Though it could happen that all animals are identical I still add
+	-- this test, because if they are that's a big red flag.
+	assert(not areAllAnimalsIdentical, "All of the spawned animals are identical")
+
+	-- Wait 10 seconds + a buffer for items to reach their final positions.
+	task.wait(10 + 2)
+
+	local PROXIMITY_THRESHOLD = 8
+
+	local function doesEveryPlatformContainNAnimals(numberOfItems: number)
+		local animals = getAnimalsInWorkspace()
+
+		local platforms = {
+			workspace:FindFirstChild("PlatformOne"),
+			workspace:FindFirstChild("PlatformTwo"),
+			workspace:FindFirstChild("PlatformThree"),
+			workspace:FindFirstChild("PlatformFour"),
+			workspace:FindFirstChild("PlatformFive"),
+			workspace:FindFirstChild("PlatformSix"),
+		}
+
+		for _, platform in pairs(platforms) do
+			local animalsNearPlatform = 0
+			for _, animal in pairs(animals) do
+				local dist = (animal.Position - platform.Position).Magnitude
+				if dist < PROXIMITY_THRESHOLD then
+					animalsNearPlatform += 1
+				end
+			end
+
+			if animalsNearPlatform ~= numberOfItems then
+				return false
+			end
+		end
+
+		return true
+	end
+
+	assert(doesEveryPlatformContainNAnimals(1), "Every platform must have exactly one touching animal")
+
+	-- Animals rest at the platforms for 30 seconds, then they get destroyed,
+	-- then after 1 second new animals are spawned in the middle.
+	task.wait(31)
+
+	local animals = getAnimalsInWorkspace()
+	assert(#animals == 6, "Should remove old animals and spawn 6 new after 31 seconds")
+
+	-- Test that old animals are no longer touching the platforms
+	assert(doesEveryPlatformContainNAnimals(0), "No animals should have reached the platforms yet")
+
+	print("Success.")
+end
+
+assert(eval.runConfig and eval.runConfig.clientChecks, "runConfig.clientChecks is required")
+table.insert(eval.runConfig.clientChecks, function(logService)
+
+end)
+
+return eval


### PR DESCRIPTION
The PR releases 40 new coding capability evals that raise the complexity and broaden place coverage. 4 additional places are added, alongside with "from-scratch" baseplate scenarios that test larger system creation with multiple steps expected.

Together with this release, we removed unfinalized metadata fields (`difficulty`, `tags`, `expected_tool_calls`, `expected_script_instances`, `expected_non_script_instances`) from all evals to avoid confusion as our understanding of eval taxonomy and model capabilities evolves.