### PR TITLE
Update with claude

### DIFF
--- a/LLM_LEADERBOARD.md
+++ b/LLM_LEADERBOARD.md
@@ -62,7 +62,7 @@
         <td>14.15%</td>
         <td>4.00%</td>
         <td>-</td>
-    </tr>,,,
+    </tr>
     <tr>
         <td class="model-name">Claude Opus 4.7</td>
         <td>46.38%</td>

--- a/LLM_LEADERBOARD.md
+++ b/LLM_LEADERBOARD.md
@@ -62,6 +62,15 @@
         <td>14.15%</td>
         <td>4.00%</td>
         <td>-</td>
+    </tr>,,,
+    <tr>
+        <td class="model-name">Claude Opus 4.7</td>
+        <td>46.38%</td>
+        <td>61.34%</td>
+        <td>45.44%</td>
+        <td>34.87%</td>
+        <td>2.24%</td>
+        <td>52.67%</td>
     </tr>
     <tr>
         <td class="model-name">Claude Opus 4.6</td>


### PR DESCRIPTION
Deep dive on Claude regression:

Using the same system prompt and same tools, Opus 4.7  makes ~40% fewer tool calls compared to 4.6, with the largest drops in exploration tools (`inspect_instance`, `script_grep`, `script_search`, 'search_game_tree').  This results in a drop in pass rates compared to 4.6.

Opus 4.7 does fewer exploratory tool calls on the codebase and game state, and sometimes gives up after initial searches fail, missing objects that broader structural exploration would reveal. Core action tools (`execute_luau`, `multi_edit`) remain similar.

This is consistent with regressions reported in [4.7's own system card](https://cdn.sanity.io/files/4zrzovbb/website/037f06850df7fbe871e206dad004c3db5fd50340.pdf) that shows lower scores versus 4.6 on agentic search benchmarks like MRCR, DeepSearchQA, and BrowseComp.

If using 4.7, optimizing your system prompt to encourage exploration steps could help.

